### PR TITLE
Keep terraform block when remote backend is not enabled.

### DIFF
--- a/templates/tfengine/components/bootstrap/main.tf
+++ b/templates/tfengine/components/bootstrap/main.tf
@@ -35,7 +35,6 @@ terraform {
 {{- end}}
 }
 
-
 # Create the project, enable APIs, and create the deletion lien, if specified.
 module "project" {
   source  = "terraform-google-modules/project-factory/google"

--- a/templates/tfengine/components/bootstrap/main.tf
+++ b/templates/tfengine/components/bootstrap/main.tf
@@ -21,19 +21,20 @@
 # - Org level IAM permissions for org admins.
 
 // TODO: replace with https://github.com/terraform-google-modules/terraform-google-bootstrap
-{{- if enabled . "BOOTSTRAP_GCS_BACKEND"}}
 terraform {
   required_version = "~> 0.12.0"
   required_providers {
     google      = "~> 3.0"
     google-beta = "~> 3.0"
   }
+{{- if enabled . "BOOTSTRAP_GCS_BACKEND"}}
   backend "gcs" {
     bucket = "{{.STATE_BUCKET}}"
     prefix = "bootstrap"
   }
-}
 {{- end}}
+}
+
 
 # Create the project, enable APIs, and create the deletion lien, if specified.
 module "project" {

--- a/templates/tfengine/components/org/monitor/forseti/main.tf
+++ b/templates/tfengine/components/org/monitor/forseti/main.tf
@@ -20,12 +20,13 @@ module "forseti" {
   source  = "terraform-google-modules/forseti/google"
   version = "~> 5.2.0"
 
-  domain           = var.domain
-  project_id       = var.project_id
-  org_id           = var.org_id
-  network          = "forseti-vpc"
-  subnetwork       = "forseti-subnet"
-  client_enabled   = false
-  server_private   = true
-  cloudsql_private = true
+  domain               = var.domain
+  project_id           = var.project_id
+  org_id               = var.org_id
+  network              = "forseti-vpc"
+  subnetwork           = "forseti-subnet"
+  client_enabled       = false
+  server_private       = true
+  cloudsql_private     = true
+  manage_rules_enabled = false
 }


### PR DESCRIPTION
- terraform provider version should still be pinned when remote backend is disabled
- Set Forseti module to not manage rules