### PR TITLE
Use bash as entrypoint to run deletion check script.

### DIFF
--- a/templates/tfengine/components/cicd/configs/tf-deletion-check.sh
+++ b/templates/tfengine/components/cicd/configs/tf-deletion-check.sh
@@ -11,7 +11,7 @@
 
 set -e
 
-echo -e 'Checking for Terraform deletions\n'
+echo -e 'Checking for resource deletions...\n'
 
 # Parse every plan
 found_deletes="false"
@@ -36,4 +36,6 @@ done
 
 if [[ "${found_deletes}" == 'true' ]]; then
   echo >&2 'Destructive changes should be reviewed carefully by a human operator before being applied by automation.'
+else
+  echo >&2 'No resource deletion found.'
 fi

--- a/templates/tfengine/components/cicd/configs/tf-plan.yaml
+++ b/templates/tfengine/components/cicd/configs/tf-plan.yaml
@@ -33,7 +33,8 @@ steps:
 
   # Check for delete operations as an FYI, it won't fail the build.
   - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools@sha256:a09ad46f513847d31e2cfe20f818c2d64809e7d12695e2e6098900296f6527bf"
-    entrypoint: '/workspace/${_TERRAFORM_ROOT}/cicd/configs/tf-deletion-check.sh'
+    entrypoint: bash
+    args: ["../cicd/configs/tf-deletion-check.sh"]
     dir: "${_TERRAFORM_ROOT}/org"
 
 substitutions:


### PR DESCRIPTION
The auto-generated tf-deletion-check.yaml file from engine does not
always have execution permission. Use bash as entrypoint is safer.