### PR TITLE
Use later version of Node for md_check

### DIFF
--- a/build/go_check.sh
+++ b/build/go_check.sh
@@ -15,6 +15,9 @@
 #!/bin/bash
 set -e
 
+# Print versions
+go version
+
 # Check format
 f=$(gofmt -l .)
 if [[ "${f}" ]]; then

--- a/build/md_check.sh
+++ b/build/md_check.sh
@@ -15,6 +15,10 @@
 #!/bin/bash
 set -e
 
+# Print versions
+npm version
+
 # Check format
-npm install -g markdownlint-cli@0.22.0
+# Note: Requires Node 10+ (see https://github.com/igorshubovych/markdownlint-cli/issues/90)
+npm install -g markdownlint-cli
 markdownlint **/*.md

--- a/build/presubmit.yaml
+++ b/build/presubmit.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 steps:
-- name: "gcr.io/cloud-builders/npm"
+- name: "gcr.io/cloud-builders/npm:current"
   entrypoint: "sh"
   args: ["build/md_check.sh"]
 


### PR DESCRIPTION
See https://github.com/igorshubovych/markdownlint-cli/issues/90#issuecomment-624266496:
```
The CLI advertises a minimum version of Node 10
```

The gcr.io/cloud-builders/npm container seems to have a `node-10.10.0` tag, but that's static, and `current` is also 10+ and seems to be later than `latest` (unintuitive).