### PR TITLE
Remove log message for not found provider config

### DIFF
--- a/internal/terraform/json.go
+++ b/internal/terraform/json.go
@@ -229,8 +229,6 @@ func resourceProviderConfig(kind string, name string, plan *plan) (pc ProviderCo
 		}
 	}
 
-	log.Printf("Could not find provider config key for resource %v.%v", kind, name)
-
 	return ProviderConfig{}, false
 }
 


### PR DESCRIPTION
This make the logs look ugly.