### PR TITLE
simplify audit and monitor

### DIFF
--- a/examples/tfengine/full.yaml
+++ b/examples/tfengine/full.yaml
@@ -18,7 +18,7 @@ data:
   ORG_ID: "123"
   BILLING_ACCOUNT: "000-000-000"
 
-  # Global locations for resources. Can be overridden in individual templates.
+  # Default locations for resources. Can be overridden in individual templates.
   BIGQUERY_DATASET_LOCATION: "us-east1"
   CLOUD_SQL_INSTANCE_REGION: "us-central1"
   COMPUTE_INSTANCE_REGION: "us-central1"

--- a/examples/tfengine/full.yaml
+++ b/examples/tfengine/full.yaml
@@ -17,8 +17,15 @@
 data:
   ORG_ID: "123"
   BILLING_ACCOUNT: "000-000-000"
-  STORAGE_LOCATION: "us-central1"
-  CLUSTER_REGION: "us-central1"
+
+  # Global locations for resources. Can be overridden in individual templates.
+  BIGQUERY_DATASET_LOCATION: "us-east1"
+  CLOUD_SQL_INSTANCE_REGION: "us-central1"
+  COMPUTE_INSTANCE_REGION: "us-central1"
+  COMPUTE_NETWORK_REGION: "us-central1"
+  GKE_CLUSTER_REGION: "us-central1"
+  STORAGE_BUCKET_LOCATION: "us-central1"
+
   MASTER_AUTHORIZED_NETWORKS:
   - DISPLAY_NAME: "Office"
     CIDR_BLOCK: "192.0.2.0/24"

--- a/examples/tfengine/simple.yaml
+++ b/examples/tfengine/simple.yaml
@@ -17,7 +17,14 @@
 data:
   ORG_ID: "123"
   BILLING_ACCOUNT: "000-000-000"
-  STORAGE_LOCATION: "us-central1"
+
+   # Global locations for resources. Can be overridden in individual templates.
+  BIGQUERY_DATASET_LOCATION: "us-east1"
+  CLOUD_SQL_INSTANCE_REGION: "us-central1"
+  COMPUTE_INSTANCE_REGION: "us-central1"
+  COMPUTE_NETWORK_REGION: "us-central1"
+  GKE_CLUSTER_REGION: "us-central1"
+  STORAGE_BUCKET_LOCATION: "us-central1"
 
   # TODO: This block prevents certain parts of the configs from being generated
   # which require dependencies to be deployed first.

--- a/examples/tfengine/simple.yaml
+++ b/examples/tfengine/simple.yaml
@@ -18,7 +18,7 @@ data:
   ORG_ID: "123"
   BILLING_ACCOUNT: "000-000-000"
 
-   # Global locations for resources. Can be overridden in individual templates.
+  # Default locations for resources. Can be overridden in individual templates.
   BIGQUERY_DATASET_LOCATION: "us-east1"
   CLOUD_SQL_INSTANCE_REGION: "us-central1"
   COMPUTE_INSTANCE_REGION: "us-central1"

--- a/templates/tfengine/components/org/audit/main.tf
+++ b/templates/tfengine/components/org/audit/main.tf
@@ -57,9 +57,9 @@ module "bigquery_destination" {
   source  = "terraform-google-modules/bigquery/google"
   version = "~> 4.1.0"
 
-  dataset_id                  = var.dataset_name
+  dataset_id                  = "{{.DATASET_NAME}}"
   project_id                  = var.project_id
-  location                    = "us-east1"
+  location                    = "{{.BIGQUERY_DATASET_LOCATION}}"
   default_table_expiration_ms = 365 * 8.64 * pow(10, 7) # 365 days
   access = [
     {
@@ -98,9 +98,9 @@ module "storage_destination" {
   source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
   version = "~> 1.5.0"
 
-  name          = var.bucket_name
+  name          = "{{.BUCKET_NAME}}"
   project_id    = var.project_id
-  location      = "us-central1"
+  location      = "{{.STORAGE_BUCKET_LOCATION}}"
   storage_class = "COLDLINE"
 
   lifecycle_rules = [{

--- a/templates/tfengine/components/org/audit/terraform.tfvars
+++ b/templates/tfengine/components/org/audit/terraform.tfvars
@@ -13,7 +13,4 @@
 # limitations under the License.
 
 org_id       = "{{.ORG_ID}}"
-project_id   = "{{.PROJECT_ID}}"
-dataset_name = "{{.DATASET_NAME}}"
-bucket_name  = "{{.BUCKET_NAME}}"
 auditors     = "{{.AUDITORS}}"

--- a/templates/tfengine/components/org/audit/terragrunt.hcl
+++ b/templates/tfengine/components/org/audit/terragrunt.hcl
@@ -16,8 +16,13 @@ include {
   path = find_in_parent_folders()
 }
 
-dependencies {
-  paths = [
-    "../project.{{.PROJECT_ID}}/project",
-  ]
+dependency "project" {
+  config_path = "../project"
+  mock_outputs = {
+    project_id = "mock-project"
+  }
+}
+
+inputs = {
+  project_id = dependency.project.outputs.project_id
 }

--- a/templates/tfengine/components/org/audit/variables.tf
+++ b/templates/tfengine/components/org/audit/variables.tf
@@ -20,14 +20,6 @@ variable "project_id" {
   type = string
 }
 
-variable "dataset_name" {
-  type = string
-}
-
-variable "bucket_name" {
-  type = string
-}
-
 variable "auditors" {
   type = string
 }

--- a/templates/tfengine/components/org/monitor/forseti/terraform.tfvars
+++ b/templates/tfengine/components/org/monitor/forseti/terraform.tfvars
@@ -13,8 +13,3 @@
 # limitations under the License.
 
 org_id     = "{{.ORG_ID}}"
-project_id = "{{.PROJECT_ID}}"
-domain     = "{{.DOMAIN}}"
-{{- if has . "REGION"}}
-region     = {{.REGION}}
-{{- end}}

--- a/templates/tfengine/components/org/monitor/forseti/terragrunt.hcl
+++ b/templates/tfengine/components/org/monitor/forseti/terragrunt.hcl
@@ -16,8 +16,13 @@ include {
   path = find_in_parent_folders()
 }
 
-dependencies {
-  paths = [
-    "../../project.{{.PROJECT_ID}}/project",
-  ]
+dependency "project" {
+  config_path = "../project"
+  mock_outputs = {
+    project_id = "mock-project"
+  }
+}
+
+inputs = {
+  project_id = dependency.project.outputs.project_id
 }

--- a/templates/tfengine/components/org/monitor/forseti/variables.tf
+++ b/templates/tfengine/components/org/monitor/forseti/variables.tf
@@ -19,12 +19,3 @@ variable "org_id" {
 variable "project_id" {
   type = string
 }
-
-variable "domain" {
-  type = string
-}
-
-variable "region" {
-  type    = string
-  default = "us-central1"
-}

--- a/templates/tfengine/recipes/org/audit.yaml
+++ b/templates/tfengine/recipes/org/audit.yaml
@@ -1,10 +1,15 @@
 templates:
+- name: "dir"
+  output_path: "audit"
 - name: "project"
   recipe_path: "./project.yaml"
+  output_ref: "dir"
   data:
+    OUTPUT_PATH: ""
     APIS:
     - "bigquery.googleapis.com"
     - "logging.googleapis.com"
 - name: "audit"
   component_path: "../../components/org/audit"
-  output_path: "./audit"
+  output_ref: "dir"
+  output_path: "./resources"

--- a/templates/tfengine/recipes/org/monitor.yaml
+++ b/templates/tfengine/recipes/org/monitor.yaml
@@ -1,6 +1,12 @@
 templates:
+- name: "dir"
+  output_path: "monitor"
 - name: "project"
   recipe_path: "./project.yaml"
+  output_ref: "dir"
+  data:
+    OUTPUT_PATH: ""
 - name: "forseti"
   component_path: "../../components/org/monitor/forseti"
-  output_path: "./monitor/forseti"
+  output_ref: "dir"
+  output_path: "./forseti"

--- a/templates/tfengine/recipes/org/project.yaml
+++ b/templates/tfengine/recipes/org/project.yaml
@@ -1,6 +1,10 @@
 templates:
 - name: "dir"
+  {{if has . "OUTPUT_PATH"}}
+  output_path: "{{.OUTPUT_PATH}}"
+  {{else}}
   output_path: "./project.{{.PROJECT_ID}}"
+  {{end}}
 - name: "terragrunt"
   component_path: "../../components/terragrunt/leaf"
   output_ref: "dir"


### PR DESCRIPTION
Change the audit and monitor dir structure to the following:

org/audit/project
org/audit/resources
org/monitor/project
org/monitor/resources

Also support overriding individual resource locations.