### PR TITLE
Upgrade project factory to new release, add support for shared VPC

### DIFF
--- a/examples/tfengine/full.yaml
+++ b/examples/tfengine/full.yaml
@@ -120,7 +120,7 @@ templates:
     APIS:
     - "container.googleapis.com"
     SHARED_VPC:
-      HOST_PROJECT: "example-prod-networks"
+      HOST_PROJECT_ID: "example-prod-networks"
       SUBNETS:
       - NAME: example-subnet
     RESOURCES:

--- a/examples/tfengine/full.yaml
+++ b/examples/tfengine/full.yaml
@@ -120,9 +120,10 @@ templates:
     APIS:
     - "container.googleapis.com"
     SHARED_VPC:
-      HOST: "example-prod-networks"
+      HOST_PROJECT: "example-prod-networks"
       SUBNETS:
-      - "projects/example-prod-networks/regions/us-central1/subnetworks/example-subnet"
+      - NAME: example-subnet
+      # - "projects/example-prod-networks/regions/us-central1/subnetworks/example-subnet"
     RESOURCES:
       GKE_CLUSTERS:
       - NAME: "example-prod-gke-cluster"

--- a/examples/tfengine/full.yaml
+++ b/examples/tfengine/full.yaml
@@ -123,7 +123,6 @@ templates:
       HOST_PROJECT: "example-prod-networks"
       SUBNETS:
       - NAME: example-subnet
-      # - "projects/example-prod-networks/regions/us-central1/subnetworks/example-subnet"
     RESOURCES:
       GKE_CLUSTERS:
       - NAME: "example-prod-gke-cluster"

--- a/examples/tfengine/full.yaml
+++ b/examples/tfengine/full.yaml
@@ -112,11 +112,17 @@ templates:
         IAM_MEMBERS:
         - ROLE: "roles/storage.objectViewer"
           MEMBER: "group:example-readers@example.com"
-- name: "project-example-apps"
+- name: "project-example-prod-apps"
   recipe_path: "{{$BASE}}/folder/project.yaml"
   output_ref: "folder-prod-team1.dir"
   data:
     PROJECT_ID: "example-prod-apps"
+    APIS:
+    - "container.googleapis.com"
+    SHARED_VPC:
+      HOST: "example-prod-networks"
+      SUBNETS:
+      - "projects/example-prod-networks/regions/us-central1/subnetworks/example-subnet"
     RESOURCES:
       GKE_CLUSTERS:
       - NAME: "example-prod-gke-cluster"

--- a/internal/template/funcmap.go
+++ b/internal/template/funcmap.go
@@ -39,15 +39,15 @@ func get(m map[string]interface{}, key string, def ...interface{}) interface{} {
 		v, ok := m[k]
 		switch {
 		case !ok:
+			if len(def) == 1 {
+				return def[0]
+			}
 			return nil
 		case i == len(split)-1:
 			return v
 		default:
 			m = v.(map[string]interface{})
 		}
-	}
-	if len(def) == 1 {
-		return def[0]
 	}
 	return nil
 }

--- a/internal/template/funcmap.go
+++ b/internal/template/funcmap.go
@@ -28,8 +28,7 @@ var funcMap = map[string]interface{}{
 // get allows a template to optionally lookup a value from a dict.
 // If a value is not found, it will check for a single default.
 // If there is no default, it will return nil.
-//   {{if get . "OPTIONAL_KEY"}} {{.}} {{end}}  // GOOD
-//   {{.OPTIONAL_KEY}}  // BAD, will fail if the key is not set
+// There should be at most one default value set.
 //
 // Keys can reference multiple levels of maps by using "." to indicate a new level
 // (e.g. L1.L2 will lookup key L1 in the top level map then L2 within the value.)

--- a/internal/template/funcmap.go
+++ b/internal/template/funcmap.go
@@ -26,13 +26,14 @@ var funcMap = map[string]interface{}{
 }
 
 // get allows a template to optionally lookup a value from a dict.
-// If a value is not found, return nil.
+// If a value is not found, it will check for a single default.
+// If there is no default, it will return nil.
 //   {{if get . "OPTIONAL_KEY"}} {{.}} {{end}}  // GOOD
 //   {{.OPTIONAL_KEY}}  // BAD, will fail if the key is not set
 //
 // Keys can reference multiple levels of maps by using "." to indicate a new level
 // (e.g. L1.L2 will lookup key L1 in the top level map then L2 within the value.)
-func get(m map[string]interface{}, key string) interface{} {
+func get(m map[string]interface{}, key string, def ...interface{}) interface{} {
 	split := strings.Split(key, ".")
 	for i, k := range split {
 		v, ok := m[k]
@@ -44,6 +45,9 @@ func get(m map[string]interface{}, key string) interface{} {
 		default:
 			m = v.(map[string]interface{})
 		}
+	}
+	if len(def) == 1 {
+		return def[0]
 	}
 	return nil
 }

--- a/templates/tfengine/components/project/gke_clusters/main.tf
+++ b/templates/tfengine/components/project/gke_clusters/main.tf
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */ -}}
 
-{{range get . "GKE_CLUSTERS" -}}
+{{range get . "GKE_CLUSTERS"}}
 module "{{resourceName .NAME}}" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/safer-cluster-update-variant"
   version = "9.0.0"

--- a/templates/tfengine/components/project/gke_clusters/main.tf
+++ b/templates/tfengine/components/project/gke_clusters/main.tf
@@ -20,7 +20,7 @@ module "{{resourceName .NAME}}" {
   # Required.
   name                   = "{{.NAME}}"
   project_id             = var.project_id
-  region                 = "{{get . "REGION" $.GKE_CLUSTER_REGION }}"
+  region                 = "{{get . "REGION" $.GKE_CLUSTER_REGION}}"
   regional               = true
   network                = "{{.NETWORK}}"
   subnetwork             = "{{.SUBNET}}"

--- a/templates/tfengine/components/project/gke_clusters/main.tf
+++ b/templates/tfengine/components/project/gke_clusters/main.tf
@@ -12,7 +12,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */ -}}
 
-{{range get . "GKE_CLUSTERS"}}
+{{- range get . "GKE_CLUSTERS"}}
+
+{{- $region := get . "REGION"}}
+{{- if not $region}}
+{{- $region = $.GKE_CLUSTER_REGION}}
+{{- end}}
+
 module "{{resourceName .NAME}}" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/safer-cluster-update-variant"
   version = "9.0.0"
@@ -20,11 +26,7 @@ module "{{resourceName .NAME}}" {
   # Required.
   name                   = "{{.NAME}}"
   project_id             = var.project_id
-  {{- if has . "REGION"}}
-  region                 = "{{.REGION}}"
-  {{- else}}
-  region                 = "{{$.GKE_CLUSTER_REGION}}"
-  {{- end}}
+  region                 = "{{$region}}"
   regional               = true
   network                = "{{.NETWORK}}"
   subnetwork             = "{{.SUBNET}}"
@@ -39,4 +41,4 @@ module "{{resourceName .NAME}}" {
   enable_private_endpoint    = false
   release_channel            = "STABLE"
 }
-{{end}}
+{{- end}}

--- a/templates/tfengine/components/project/gke_clusters/main.tf
+++ b/templates/tfengine/components/project/gke_clusters/main.tf
@@ -12,13 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */ -}}
 
-{{- range get . "GKE_CLUSTERS"}}
-
-{{- $region := get . "REGION"}}
-{{- if not $region}}
-{{- $region = $.GKE_CLUSTER_REGION}}
-{{- end}}
-
+{{range get . "GKE_CLUSTERS" -}}
 module "{{resourceName .NAME}}" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/safer-cluster-update-variant"
   version = "9.0.0"
@@ -26,7 +20,7 @@ module "{{resourceName .NAME}}" {
   # Required.
   name                   = "{{.NAME}}"
   project_id             = var.project_id
-  region                 = "{{$region}}"
+  region                 = "{{get . "REGION" $.GKE_CLUSTER_REGION }}"
   regional               = true
   network                = "{{.NETWORK}}"
   subnetwork             = "{{.SUBNET}}"

--- a/templates/tfengine/components/project/project/main.tf
+++ b/templates/tfengine/components/project/project/main.tf
@@ -36,8 +36,8 @@ module "project" {
     "projects/{{$host}}/regions/{{$region}}/subnetworks/{{.NAME}}",
     {{- end}}
   ]
-  {{- end}}
-  {{- end}}
+  {{- end /* shared VPC subnets */}}
+  {{- end /* shared VPC */}}
 
   {{- if has . "APIS"}}
   activate_apis = [

--- a/templates/tfengine/components/project/project/main.tf
+++ b/templates/tfengine/components/project/project/main.tf
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */ -}}
 
-# Create the project, enable APIs, and create the deletion lien, if specified.
+# Create the project and optionally enable APIs, create the deletion lien and add to shared VPC.
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 8.0.0"
@@ -21,17 +21,19 @@ module "project" {
   org_id                  = var.org_id
   folder_id               = var.folder_id
   billing_account         = var.billing_account
-  lien                    = {{get . "ENABLE_LIEN" "true"}}
+  lien                    = {{get . "ENABLE_LIEN" true}}
   default_service_account = "keep"
   skip_gcloud_download    = true
 
   {{- if has . "SHARED_VPC"}}
-  shared_vpc              = "{{.SHARED_VPC.HOST}}"
+  {{- $host := .SHARED_VPC.HOST_PROJECT}}
+  shared_vpc              = "{{$host}}"
 
-  {{- if has . "SHARED_VPC.SUBNETS"}}
+  {{- if has .SHARED_VPC "SUBNETS"}}
   shared_vpc_subnets = [
     {{- range get . "SHARED_VPC.SUBNETS"}}
-    "{{.}}",
+    {{- $region := get . "REGION" $.COMPUTE_NETWORK_REGION}}
+    "projects/{{$host}}/regions/{{$region}}/subnetworks/{{.NAME}}",
     {{- end}}
   ]
   {{- end}}

--- a/templates/tfengine/components/project/project/main.tf
+++ b/templates/tfengine/components/project/project/main.tf
@@ -14,10 +14,10 @@
 
 # Create the project, enable APIs, and create the deletion lien, if specified.
 module "project" {
-  source  = "terraform-google-modules/project-factory/google"
-  version = "~> 7.0"
+  source  = "terraform-google-modules/project-factory/google//modules/core_project_factory"
+  version = "~> 8.0.0"
 
-  name                    = var.name
+  name                    = "{{.PROJECT_ID}}"
   org_id                  = var.org_id
   folder_id               = var.folder_id
   billing_account         = var.billing_account

--- a/templates/tfengine/components/project/project/main.tf
+++ b/templates/tfengine/components/project/project/main.tf
@@ -21,8 +21,8 @@ module "project" {
   org_id                  = var.org_id
   folder_id               = var.folder_id
   billing_account         = var.billing_account
-  lien                    = var.enable_lien
   activate_apis           = var.apis
+  enable_lien             = {{get . "ENABLE_LIEN" true}}
   default_service_account = "keep"
   skip_gcloud_download    = true
 }

--- a/templates/tfengine/components/project/project/main.tf
+++ b/templates/tfengine/components/project/project/main.tf
@@ -1,28 +1,47 @@
-# Copyright 2020 Google Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+{{- /* Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */ -}}
 
 # Create the project, enable APIs, and create the deletion lien, if specified.
 module "project" {
-  source  = "terraform-google-modules/project-factory/google//modules/core_project_factory"
+  source  = "terraform-google-modules/project-factory/google"
   version = "~> 8.0.0"
 
   name                    = "{{.PROJECT_ID}}"
   org_id                  = var.org_id
   folder_id               = var.folder_id
   billing_account         = var.billing_account
-  activate_apis           = var.apis
-  enable_lien             = {{get . "ENABLE_LIEN" true}}
+  lien                    = {{get . "ENABLE_LIEN" "true"}}
   default_service_account = "keep"
   skip_gcloud_download    = true
+
+  {{- if has . "SHARED_VPC"}}
+  shared_vpc              = "{{.SHARED_VPC.HOST}}"
+
+  {{- if has . "SHARED_VPC.SUBNETS"}}
+  shared_vpc_subnets = [
+    {{- range get . "SHARED_VPC.SUBNETS"}}
+    "{{.}}",
+    {{- end}}
+  ]
+  {{- end}}
+  {{- end}}
+
+  {{- if has . "APIS"}}
+  activate_apis = [
+    {{- range .APIS}}
+    "{{.}}",
+    {{- end}}
+  ]
+  {{- end}}
 }

--- a/templates/tfengine/components/project/project/main.tf
+++ b/templates/tfengine/components/project/project/main.tf
@@ -26,7 +26,7 @@ module "project" {
   skip_gcloud_download    = true
 
   {{- if has . "SHARED_VPC"}}
-  {{- $host := .SHARED_VPC.HOST_PROJECT}}
+  {{- $host := .SHARED_VPC.HOST_PROJECT_ID}}
   shared_vpc              = "{{$host}}"
 
   {{- if has .SHARED_VPC "SUBNETS"}}

--- a/templates/tfengine/components/project/project/main.tf
+++ b/templates/tfengine/components/project/project/main.tf
@@ -33,11 +33,11 @@ module "project" {
   shared_vpc_subnets = [
     {{- range get . "SHARED_VPC.SUBNETS"}}
     {{- $region := get . "REGION" $.COMPUTE_NETWORK_REGION}}
-    "projects/{{$host}}/regions/{{$region}}/subnetworks/{{.NAME}}",
+    "projects/{{ $host }}/regions/{{$region}}/subnetworks/{{.NAME}}",
     {{- end}}
   ]
-  {{- end /* shared VPC subnets */}}
-  {{- end /* shared VPC */}}
+  {{- end}} {{/* shared VPC subnets */}}
+  {{- end}} {{/* shared VPC */}}
 
   {{- if has . "APIS"}}
   activate_apis = [

--- a/templates/tfengine/components/project/project/terraform.tfvars
+++ b/templates/tfengine/components/project/project/terraform.tfvars
@@ -14,10 +14,3 @@
 
 org_id          = "{{.ORG_ID}}"
 billing_account = "{{.BILLING_ACCOUNT}}"
-{{- if index . "APIS"}}
-apis = [
-  {{- range .APIS}}
-  "{{.}}",
-  {{- end}}
-]
-{{- end}}

--- a/templates/tfengine/components/project/project/terraform.tfvars
+++ b/templates/tfengine/components/project/project/terraform.tfvars
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name            = "{{.PROJECT_ID}}"
 org_id          = "{{.ORG_ID}}"
 billing_account = "{{.BILLING_ACCOUNT}}"
 {{- if has . "ENABLE_LIEN"}}

--- a/templates/tfengine/components/project/project/terraform.tfvars
+++ b/templates/tfengine/components/project/project/terraform.tfvars
@@ -14,9 +14,6 @@
 
 org_id          = "{{.ORG_ID}}"
 billing_account = "{{.BILLING_ACCOUNT}}"
-{{- if has . "ENABLE_LIEN"}}
-enable_lien     = {{.ENABLE_LIEN}}
-{{- end}}
 {{- if index . "APIS"}}
 apis = [
   {{- range .APIS}}

--- a/templates/tfengine/components/project/project/variables.tf
+++ b/templates/tfengine/components/project/project/variables.tf
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-variable "name" {
-  type = string
-}
-
 variable "org_id" {
   type = string
 }
@@ -27,14 +23,4 @@ variable "folder_id" {
 
 variable "billing_account" {
   type = string
-}
-
-variable "apis" {
-  type    = list(string)
-  default = []
-}
-
-variable "enable_lien" {
-  type    = bool
-  default = true
 }


### PR DESCRIPTION
NOTE: CFT implements shared VPC inside the project factory module. This is a bit against our curent convention which puts all resources (including all iam) for a project within the project's dir. So in my studies case we had the networks deployment take all service projects as dependencies.

However, project factory instead tries to attach the project to the host project (making the deployment dependency). This approach greatly simplifies the overall configs. Thus, I will use the CFT approach here. In general, we may consider allowing resources like IAM to be defined elsewhere in configs if it greatly simplifies the deployments.

Another con is now someone deploying the apps project also needs permission on the network project to depoy these changes.

There still needs to be dependency to correctly make the apps depend on network.

Also fix #77 