### PR TITLE
Add SimpleImporter

### DIFF
--- a/internal/tfimport/importer/resources_test.go
+++ b/internal/tfimport/importer/resources_test.go
@@ -16,6 +16,8 @@ package importer
 
 import (
 	"testing"
+
+	"github.com/GoogleCloudPlatform/healthcare-data-protection-suite/internal/terraform"
 )
 
 var configs = []ProviderConfigMap{
@@ -32,28 +34,36 @@ var configs = []ProviderConfigMap{
 	},
 }
 
+var resourceChange = terraform.ResourceChange{
+	Change: terraform.Change{
+		After: map[string]interface{}{
+			"project": "myproject",
+			"name":    "myresourcename",
+		},
+	},
+}
+
 func TestFromConfigValuesGot(t *testing.T) {
 	tests := []struct {
 		key  string
-		cvs  []ProviderConfigMap
 		want interface{}
 	}{
 		// Empty key - should still work.
-		{"", configs, "emptyValFirst"},
+		{"", "emptyValFirst"},
 
 		// Key in second config - should return second one, not nil.
-		{"mykey3", configs, "key3Second"},
+		{"mykey3", "key3Second"},
 
 		// Key in both configs - should return first one.
-		{"mykey1", configs, "key1First"},
+		{"mykey1", "key1First"},
 	}
 	for _, tc := range tests {
-		got, err := fromConfigValues(tc.key, tc.cvs...)
+		got, err := fromConfigValues(tc.key, configs...)
 		if err != nil {
-			t.Errorf("fromConfigValues(%v, %v) failed: %s", tc.key, tc.cvs, err)
+			t.Errorf("fromConfigValues(%v, %v) failed: %s", tc.key, configs, err)
 		}
 		if got != tc.want {
-			t.Errorf("fromConfigValues(%v, %v) = %v; want %v", tc.key, tc.cvs, got, tc.want)
+			t.Errorf("fromConfigValues(%v, %v) = %v; want %v", tc.key, configs, got, tc.want)
 		}
 	}
 }
@@ -72,6 +82,46 @@ func TestFromConfigValuesErr(t *testing.T) {
 	for _, tc := range tests {
 		if _, err := fromConfigValues(tc.key, tc.cvs...); err == nil {
 			t.Errorf("fromConfigValues(%v, %v) succeeded for malformed input, want error", tc.key, tc.cvs)
+		}
+	}
+}
+
+func TestSimpleImporter(t *testing.T) {
+	tests := []struct {
+		reqFields []string
+		tmpl      string
+		want      string
+	}{
+		// Empty.
+		{[]string{}, "", ""},
+
+		// Simple case, insert some template fields.
+		{[]string{"project", "name"}, "projects/{{.project}}/resources/{{.name}}", "projects/myproject/resources/myresourcename"},
+	}
+	for _, tc := range tests {
+		imp := &SimpleImporter{Fields: tc.reqFields, Tmpl: tc.tmpl}
+		got, _ := imp.ImportID(resourceChange, configs[0])
+		if got != tc.want {
+			t.Errorf("%v ImportID(%v, %v) = %v; want %v", imp, resourceChange, configs, got, tc.want)
+		}
+	}
+}
+
+func TestSimpleImporterErr(t *testing.T) {
+	tests := []struct {
+		reqFields []string
+		tmpl      string
+	}{
+		// Field does not exist in configs.
+		{[]string{"project", "name", "version"}, "projects/{{.project}}/secrets/{{.name}}/versions/{{.version}}"},
+
+		// Template is using unknown field
+		{[]string{"project", "name"}, "projects/{{.project}}/secrets/{{.name}}/versions/{{.version}}"},
+	}
+	for _, tc := range tests {
+		imp := &SimpleImporter{Fields: tc.reqFields, Tmpl: tc.tmpl}
+		if got, err := imp.ImportID(resourceChange, configs[0]); err == nil {
+			t.Errorf("%v ImportID(%v, %v) succeeded for malformed input, want error; got = %v", imp, resourceChange, configs, got)
 		}
 	}
 }

--- a/internal/tfimport/importer/resources_test.go
+++ b/internal/tfimport/importer/resources_test.go
@@ -60,7 +60,7 @@ func TestFromConfigValuesGot(t *testing.T) {
 	for _, tc := range tests {
 		got, err := fromConfigValues(tc.key, configs...)
 		if err != nil {
-			t.Errorf("fromConfigValues(%v, %v) failed: %s", tc.key, configs, err)
+			t.Fatalf("fromConfigValues(%v, %v) failed: %s", tc.key, configs, err)
 		}
 		if got != tc.want {
 			t.Errorf("fromConfigValues(%v, %v) = %v; want %v", tc.key, configs, got, tc.want)
@@ -100,7 +100,10 @@ func TestSimpleImporter(t *testing.T) {
 	}
 	for _, tc := range tests {
 		imp := &SimpleImporter{Fields: tc.reqFields, Tmpl: tc.tmpl}
-		got, _ := imp.ImportID(resourceChange, configs[0])
+		got, err := imp.ImportID(resourceChange, configs[0])
+		if err != nil {
+			t.Fatalf("%v ImportID(%v, %v) failed: %v", imp, resourceChange, configs, err)
+		}
 		if got != tc.want {
 			t.Errorf("%v ImportID(%v, %v) = %v; want %v", imp, resourceChange, configs, got, tc.want)
 		}

--- a/internal/tfimport/importer/simple_importer.go
+++ b/internal/tfimport/importer/simple_importer.go
@@ -1,0 +1,63 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importer
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+
+	"github.com/GoogleCloudPlatform/healthcare-data-protection-suite/internal/terraform"
+)
+
+// SimpleImporter defines a struct with the necessary information to import a resource that only depends on fields from the plan.
+// Should be used by any resource that doesn't use interactivity, API calls, or complicated processing of fields.
+type SimpleImporter struct {
+	Fields []string
+	Tmpl   string
+}
+
+func loadFields(fields []string, fieldsMap map[string]string, maps ...ProviderConfigMap) error {
+	for _, field := range fields {
+		val, err := fromConfigValues(field, maps...)
+		if err != nil {
+			return err
+		}
+
+		// A bit safer to use the printf string conversion than the type assertion (i.e. val.(string)).
+		fieldsMap[field] = fmt.Sprintf("%s", val)
+	}
+	return nil
+}
+
+// ImportID returns the ID of the resource to use in importing.
+func (i *SimpleImporter) ImportID(rc terraform.ResourceChange, pcv ProviderConfigMap) (string, error) {
+	fieldsMap := make(map[string]string)
+
+	// Get required fields.
+	err := loadFields(i.Fields, fieldsMap, rc.Change.After, pcv)
+	if err != nil {
+		return "", err
+	}
+
+	// Build the template.
+	buf := &bytes.Buffer{}
+	err = template.Must(template.New("").Option("missingkey=error").Parse(i.Tmpl)).Execute(buf, fieldsMap)
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}

--- a/internal/tfimport/importer/simple_importer.go
+++ b/internal/tfimport/importer/simple_importer.go
@@ -54,7 +54,13 @@ func (i *SimpleImporter) ImportID(rc terraform.ResourceChange, pcv ProviderConfi
 
 	// Build the template.
 	buf := &bytes.Buffer{}
-	err = template.Must(template.New("").Option("missingkey=error").Parse(i.Tmpl)).Execute(buf, fieldsMap)
+	tmpl, err := template.New("").Option("missingkey=error").Parse(i.Tmpl)
+	if err != nil {
+		return "", err
+	}
+
+	// Execute the template.
+	err = tmpl.Execute(buf, fieldsMap)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This is meant to be used for most resources, where they only require values from the plan.

Resources will be migrated after submitting this change. It should make it much easier to add new resources.