### PR TITLE
Rename default locations

### DIFF
--- a/examples/tfengine/full.hcl
+++ b/examples/tfengine/full.hcl
@@ -19,12 +19,11 @@ data = {
   billing_account = "000-000-000"
 
   # Default locations for resources. Can be overridden in individual templates.
-  bigquery_dataset_location = "us-east1"
-  cloud_sql_instance_region = "us-central1"
-  compute_instance_region   = "us-central1"
-  compute_network_region    = "us-central1"
-  gke_cluster_region        = "us-central1"
-  storage_bucket_location   = "us-central1"
+  bigquery_location = "us-east1"
+  cloud_sql_region  = "us-central1"
+  compute_region    = "us-central1"
+  gke_region        = "us-central1"
+  storage_location  = "us-central1"
 
   # TODO(user): This block prevents certain parts of the configs from being
   # generated which require dependencies to be deployed first.

--- a/examples/tfengine/simple.hcl
+++ b/examples/tfengine/simple.hcl
@@ -19,11 +19,10 @@ data = {
   billing_account = "000-000-000"
 
   # Default locations for resources. Can be overridden in individual templates.
-  bigquery_dataset_location = "us-east1"
-  cloud_sql_instance_region = "us-central1"
-  compute_instance_region   = "us-central1"
-  compute_network_region    = "us-central1"
-  storage_bucket_location   = "us-central1"
+  bigquery_location = "us-east1"
+  cloud_sql_region  = "us-central1"
+  compute_region    = "us-central1"
+  storage_location  = "us-central1"
 
 
   # TODO(user): This block prevents certain parts of the configs from being

--- a/templates/tfengine/components/bootstrap/main.tf
+++ b/templates/tfengine/components/bootstrap/main.tf
@@ -58,7 +58,7 @@ module "state_bucket" {
 
   name       = var.state_bucket
   project_id = module.project.project_id
-  location   = "{{.storage_bucket_location}}"
+  location   = "{{.storage_location}}"
 }
 
 # Project level IAM permissions for devops project owners.

--- a/templates/tfengine/components/org/audit/main.tf
+++ b/templates/tfengine/components/org/audit/main.tf
@@ -59,7 +59,7 @@ module "bigquery_destination" {
 
   dataset_id                  = "{{.dataset_name}}"
   project_id                  = var.project_id
-  location                    = "{{.bigquery_dataset_location}}"
+  location                    = "{{.bigquery_location}}"
   default_table_expiration_ms = 365 * 8.64 * pow(10, 7) # 365 days
   access = [
     {
@@ -100,7 +100,7 @@ module "storage_destination" {
 
   name          = "{{.bucket_name}}"
   project_id    = var.project_id
-  location      = "{{.storage_bucket_location}}"
+  location      = "{{.storage_location}}"
   storage_class = "COLDLINE"
 
   lifecycle_rules = [{

--- a/templates/tfengine/components/org/monitor/forseti/main.tf
+++ b/templates/tfengine/components/org/monitor/forseti/main.tf
@@ -19,7 +19,7 @@ terraform {
 locals {
   forseti_vpc_name    = "forseti-vpc"
   forseti_subnet_name = "forseti-subnet"
-  forseti_subnet_key  = "{{.compute_network_region}}/${local.forseti_subnet_name}"
+  forseti_subnet_key  = "{{.compute_region}}/${local.forseti_subnet_name}"
 }
 
 # TODO(xingao): fix the data dependency in Forseti CloudSQL sub module
@@ -34,7 +34,7 @@ module "network" {
   subnets = [{
     subnet_name   = local.forseti_subnet_name
     subnet_ip     = "10.10.10.0/24"
-    subnet_region = "{{.compute_network_region}}"
+    subnet_region = "{{.compute_region}}"
   }]
 }
 
@@ -44,7 +44,7 @@ module "router" {
 
   name    = "forseti-router"
   project = var.project_id
-  region  = "{{.compute_network_region}}"
+  region  = "{{.compute_region}}"
   network = module.network.network_name
 
   nats = [{
@@ -71,10 +71,10 @@ module "forseti" {
     "organizations/${var.org_id}",
   ]
 
-  server_region           = "{{.compute_instance_region}}"
-  cloudsql_region         = "{{.cloud_sql_instance_region}}"
-  storage_bucket_location = "{{.storage_bucket_location}}"
-  bucket_cai_location     = "{{.storage_bucket_location}}"
+  server_region           = "{{.compute_region}}"
+  cloudsql_region         = "{{.cloud_sql_region}}"
+  storage_bucket_location = "{{.storage_location}}"
+  bucket_cai_location     = "{{.storage_location}}"
 
   cloudsql_private  = true
   client_enabled    = false

--- a/templates/tfengine/components/project/bigquery_datasets/main.tf
+++ b/templates/tfengine/components/project/bigquery_datasets/main.tf
@@ -19,7 +19,7 @@ module "{{resourceName .dataset_id}}" {
 
   dataset_id = "{{.dataset_id}}"
   project_id = var.project_id
-  location   = "{{get . "location" $.bigquery_dataset_location}}"
+  location   = "{{get . "location" $.bigquery_location}}"
   {{hclField . "default_table_expiration_ms" false}}
 
   {{hclField . "access" false}}

--- a/templates/tfengine/components/project/bigquery_datasets/main.tf
+++ b/templates/tfengine/components/project/bigquery_datasets/main.tf
@@ -19,7 +19,7 @@ module "{{resourceName .dataset_id}}" {
 
   dataset_id = "{{.dataset_id}}"
   project_id = var.project_id
-  location   = "{{.bigquery_location}}"
+  location   = "{{get . "location" $.bigquery_location}}"
   {{hclField . "default_table_expiration_ms" false}}
 
   {{hclField . "access" false}}

--- a/templates/tfengine/components/project/bigquery_datasets/main.tf
+++ b/templates/tfengine/components/project/bigquery_datasets/main.tf
@@ -19,7 +19,7 @@ module "{{resourceName .dataset_id}}" {
 
   dataset_id = "{{.dataset_id}}"
   project_id = var.project_id
-  location   = "{{get . "location" $.bigquery_location}}"
+  location   = "{{.bigquery_location}}"
   {{hclField . "default_table_expiration_ms" false}}
 
   {{hclField . "access" false}}

--- a/templates/tfengine/components/project/compute_networks/main.tf
+++ b/templates/tfengine/components/project/compute_networks/main.tf
@@ -27,7 +27,7 @@ module "{{resourceName .name}}" {
     {
       subnet_name            = "{{.name}}"
       subnet_ip              = "{{.ip_range}}"
-      subnet_region          = "{{get . "region" $.compute_region}}"
+      subnet_region          = "{{.compute_region}}"
       subnet_flow_logs       = true
       subnets_private_access = true
     },

--- a/templates/tfengine/components/project/compute_networks/main.tf
+++ b/templates/tfengine/components/project/compute_networks/main.tf
@@ -27,7 +27,7 @@ module "{{resourceName .name}}" {
     {
       subnet_name            = "{{.name}}"
       subnet_ip              = "{{.ip_range}}"
-      subnet_region          = "{{.compute_region}}"
+      subnet_region          = "{{get . "region" $.compute_region}}"
       subnet_flow_logs       = true
       subnets_private_access = true
     },

--- a/templates/tfengine/components/project/compute_networks/main.tf
+++ b/templates/tfengine/components/project/compute_networks/main.tf
@@ -27,11 +27,7 @@ module "{{resourceName .name}}" {
     {
       subnet_name            = "{{.name}}"
       subnet_ip              = "{{.ip_range}}"
-      {{- if has . "region"}}
-      subnet_region          = "{{.region}}"
-      {{- else}}
-      subnet_region          = "{{$.compute_network_region}}"
-      {{- end}}
+      subnet_region          = "{{get . "region" $.compute_region}}"
       subnet_flow_logs       = true
       subnets_private_access = true
     },

--- a/templates/tfengine/components/project/gke_clusters/main.tf
+++ b/templates/tfengine/components/project/gke_clusters/main.tf
@@ -20,7 +20,7 @@ module "{{resourceName .name}}" {
   # Required.
   name                   = "{{.name}}"
   project_id             = var.project_id
-  region                 = "{{get . "region" $.gke_cluster_region}}"
+  region                 = "{{get . "region" $.gke_region}}"
   regional               = true
   network                = "{{.network}}"
   subnetwork             = "{{.subnet}}"

--- a/templates/tfengine/components/project/gke_clusters/main.tf
+++ b/templates/tfengine/components/project/gke_clusters/main.tf
@@ -20,7 +20,7 @@ module "{{resourceName .name}}" {
   # Required.
   name                   = "{{.name}}"
   project_id             = var.project_id
-  region                 = "{{.gke_region}}"
+  region                 = "{{get . "region" $.gke_region}}"
   regional               = true
   network                = "{{.network}}"
   subnetwork             = "{{.subnet}}"

--- a/templates/tfengine/components/project/gke_clusters/main.tf
+++ b/templates/tfengine/components/project/gke_clusters/main.tf
@@ -20,7 +20,7 @@ module "{{resourceName .name}}" {
   # Required.
   name                   = "{{.name}}"
   project_id             = var.project_id
-  region                 = "{{get . "region" $.gke_region}}"
+  region                 = "{{.gke_region}}"
   regional               = true
   network                = "{{.network}}"
   subnetwork             = "{{.subnet}}"

--- a/templates/tfengine/components/project/project/main.tf
+++ b/templates/tfengine/components/project/project/main.tf
@@ -31,8 +31,7 @@ module "project" {
 
   shared_vpc_subnets = [
     {{- range get . "shared_vpc_attachment.subnets"}}
-    {{- $region := get . "region" $.compute_region}}
-    "projects/{{$host}}/regions/{{$region}}/subnetworks/{{.name}}",
+    "projects/{{$host}}/regions/{{.compute_region}}/subnetworks/{{.name}}",
     {{- end}}
   ]
   {{- end}}

--- a/templates/tfengine/components/project/project/main.tf
+++ b/templates/tfengine/components/project/project/main.tf
@@ -31,7 +31,7 @@ module "project" {
 
   shared_vpc_subnets = [
     {{- range get . "shared_vpc_attachment.subnets"}}
-    {{- $region := get . "region" $.compute_network_region}}
+    {{- $region := get . "region" $.compute_region}}
     "projects/{{$host}}/regions/{{$region}}/subnetworks/{{.name}}",
     {{- end}}
   ]

--- a/templates/tfengine/components/project/project/main.tf
+++ b/templates/tfengine/components/project/project/main.tf
@@ -31,7 +31,8 @@ module "project" {
 
   shared_vpc_subnets = [
     {{- range get . "shared_vpc_attachment.subnets"}}
-    "projects/{{$host}}/regions/{{.compute_region}}/subnetworks/{{.name}}",
+    {{- $region := get . "region" $.compute_region}}
+    "projects/{{$host}}/regions/{{$region}}/subnetworks/{{.name}}",
     {{- end}}
   ]
   {{- end}}

--- a/templates/tfengine/components/project/storage_buckets/main.tf
+++ b/templates/tfengine/components/project/storage_buckets/main.tf
@@ -22,7 +22,7 @@ module "{{resourceName .name}}" {
   {{- if has . "location"}}
   location   = "{{.location}}"
   {{- else}}
-  location   = "{{.storage_location}}"
+  location   = "{{$.storage_location}}"
   {{- end}}
 
   {{- if index . "iam_members"}}

--- a/templates/tfengine/components/project/storage_buckets/main.tf
+++ b/templates/tfengine/components/project/storage_buckets/main.tf
@@ -22,7 +22,7 @@ module "{{resourceName .name}}" {
   {{- if has . "location"}}
   location   = "{{.location}}"
   {{- else}}
-  location   = "{{$.storage_bucket_location}}"
+  location   = "{{$.storage_location}}"
   {{- end}}
 
   {{- if index . "iam_members"}}

--- a/templates/tfengine/components/project/storage_buckets/main.tf
+++ b/templates/tfengine/components/project/storage_buckets/main.tf
@@ -22,7 +22,7 @@ module "{{resourceName .name}}" {
   {{- if has . "location"}}
   location   = "{{.location}}"
   {{- else}}
-  location   = "{{$.storage_location}}"
+  location   = "{{.storage_location}}"
   {{- end}}
 
   {{- if index . "iam_members"}}


### PR DESCRIPTION
GCP has regions/locations by service, not individual resource. 

e.g. compute regions (https://cloud.google.com/compute/docs/regions-zones) apply to networks, instances, etc. So we should only create defaults for each service, not resource.