### PR TITLE
Add all simple resources from the full.hcl example

### DIFF
--- a/cmd/tfimport/README.md
+++ b/cmd/tfimport/README.md
@@ -71,8 +71,10 @@ Terraform configs, including importing resources from within modules.
 
 ## Supported Resources by Provider
 
-## Google (GCP)
+## [Google Cloud Platform (GCP)](https://www.terraform.io/docs/providers/google/index.html)
 
+- AppEngine
+  - [`google_app_engine_application`](https://www.terraform.io/docs/providers/google/r/app_engine_application.html)
 - BigQuery
   - [`google_bigquery_dataset`](https://www.terraform.io/docs/providers/google/r/bigquery_dataset.html)
   - [`google_bigquery_table`](https://www.terraform.io/docs/providers/google/r/bigquery_table.html)
@@ -81,41 +83,74 @@ Terraform configs, including importing resources from within modules.
 - Cloud Build
   - [`google_cloudbuild_trigger`](https://www.terraform.io/docs/providers/google/r/cloudbuild_trigger.html)
 - Cloud (Stackdriver) Logging
+  - [`google_logging_billing_account_sink`](https://www.terraform.io/docs/providers/google/r/logging_billing_account_sink.html)
+  - [`google_logging_folder_sink`](https://www.terraform.io/docs/providers/google/r/logging_folder_sink.html)
   - [`google_logging_organization_sink`](https://www.terraform.io/docs/providers/google/r/logging_organization_sink.html)
+  - [`google_logging_project_sink`](https://www.terraform.io/docs/providers/google/r/logging_project_sink.html)
 - Cloud DNS
   - [`google_dns_managed_zone`](https://www.terraform.io/docs/providers/google/r/dns_managed_zone.html)
   - [`google_dns_record_set`](https://www.terraform.io/docs/providers/google/r/dns_record_set.html)
+- Cloud Key Management Service
+  - [`google_kms_key_ring`](https://www.terraform.io/docs/providers/google/r/kms_key_ring.html)
 - Cloud Platform
+  - [`google_billing_account_iam_binding`](https://www.terraform.io/docs/providers/google/r/google_billing_account_iam_binding.html)
+  - [`google_billing_account_iam_member`](https://www.terraform.io/docs/providers/google/r/google_billing_account_iam_member.html)
+  - [`google_billing_account_iam_policy`](https://www.terraform.io/docs/providers/google/r/google_billing_account_iam_policy.html)
+  - [`google_folder`](https://www.terraform.io/docs/providers/google/r/google_folder.html)
+  - [`google_folder_iam_binding`](https://www.terraform.io/docs/providers/google/r/google_folder_iam_binding.html)
+  - [`google_folder_iam_member`](https://www.terraform.io/docs/providers/google/r/google_folder_iam_member.html)
+  - [`google_folder_iam_policy`](https://www.terraform.io/docs/providers/google/r/google_folder_iam_policy.html)
+  - [`google_folder_organization_policy`](https://www.terraform.io/docs/providers/google/r/google_folder_organization_policy.html)
   - [`google_organization_iam_audit_config`](https://www.terraform.io/docs/providers/google/r/google_organization_iam_audit_config.html)
+  - [`google_organization_iam_custom_role`](https://www.terraform.io/docs/providers/google/r/google_organization_iam_custom_role.html)
   - [`google_organization_iam_member`](https://www.terraform.io/docs/providers/google/r/google_organization_iam_member.html)
   - [`google_organization_policy`](https://www.terraform.io/docs/providers/google/r/google_organization_policy.html)
   - [`google_project`](https://www.terraform.io/docs/providers/google/r/google_project.html)
   - [`google_project_iam_binding`](https://www.terraform.io/docs/providers/google/r/google_project_iam.html#google_project_iam_binding-1)
   - [`google_project_iam_custom_role`](https://www.terraform.io/docs/providers/google/r/google_project_iam_custom_role.html)
   - [`google_project_iam_member`](https://www.terraform.io/docs/providers/google/r/google_project_iam.html#google_project_iam_member-1)
+  - [`google_project_organization_policy`](https://www.terraform.io/docs/providers/google/r/google_project_organization_policy.html)
   - [`google_project_service`](https://www.terraform.io/docs/providers/google/r/google_project_service.html)
+  - [`google_project_usage_export_bucket`](https://www.terraform.io/docs/providers/google/r/usage_export_bucket.html)
   - [`google_service_account`](https://www.terraform.io/docs/providers/google/r/google_service_account.html)
   - [`google_service_account_iam_binding`](https://www.terraform.io/docs/providers/google/r/google_service_account_iam.html)
   - [`google_service_account_iam_member`](https://www.terraform.io/docs/providers/google/r/google_service_account_iam.html)
   - [`google_service_account_iam_policy`](https://www.terraform.io/docs/providers/google/r/google_service_account_iam.html)
 - Cloud Pub/Sub
   - [`google_pubsub_subscription`](https://www.terraform.io/docs/providers/google/r/pubsub_subscription.html)
+  - [`google_pubsub_subscription_iam_binding`](https://www.terraform.io/docs/providers/google/r/pubsub_subscription_iam.html)
+  - [`google_pubsub_subscription_iam_member`](https://www.terraform.io/docs/providers/google/r/pubsub_subscription_iam.html)
+  - [`google_pubsub_subscription_iam_policy`](https://www.terraform.io/docs/providers/google/r/pubsub_subscription_iam.html)
   - [`google_pubsub_topic`](https://www.terraform.io/docs/providers/google/r/pubsub_topic.html)
+  - [`google_pubsub_topic_iam_binding`](https://www.terraform.io/docs/providers/google/r/pubsub_topic_iam.html)
+  - [`google_pubsub_topic_iam_member`](https://www.terraform.io/docs/providers/google/r/pubsub_topic_iam.html)
+  - [`google_pubsub_topic_iam_policy`](https://www.terraform.io/docs/providers/google/r/pubsub_topic_iam.html)
 - Cloud SQL
   - [`google_sql_database`](https://www.terraform.io/docs/providers/google/r/sql_database.html)
   - [`google_sql_database_instance`](https://www.terraform.io/docs/providers/google/r/sql_database_instance.html)
   - [`google_sql_user`](https://www.terraform.io/docs/providers/google/r/sql_user.html)
 - Cloud Storage
   - [`google_storage_bucket`](https://www.terraform.io/docs/providers/google/r/storage_bucket.html)
-  - [`google_storage_bucket_iam_member`](https://www.terraform.io/docs/providers/google/r/storage_bucket_iam.html#google_storage_bucket_iam_member)
+  - [`google_storage_bucket_iam_binding`](https://www.terraform.io/docs/providers/google/r/storage_bucket_iam.html)
+  - [`google_storage_bucket_iam_member`](https://www.terraform.io/docs/providers/google/r/storage_bucket_iam.html)
+  - [`google_storage_bucket_iam_policy`](https://www.terraform.io/docs/providers/google/r/storage_bucket_iam.html)
 - Compute Engine
+  - [`google_compute_address`](https://www.terraform.io/docs/providers/google/r/compute_address.html)
   - [`google_compute_firewall`](https://www.terraform.io/docs/providers/google/r/compute_firewall.html)
+  - [`google_compute_forwarding_rule`](https://www.terraform.io/docs/providers/google/r/compute_forwarding_rule.html)
   - [`google_compute_global_address`](https://www.terraform.io/docs/providers/google/r/compute_global_address.html)
+  - [`google_compute_health_check`](https://www.terraform.io/docs/providers/google/r/compute_health_check.html)
   - [`google_compute_image`](https://www.terraform.io/docs/providers/google/r/compute_image.html)
   - [`google_compute_instance`](https://www.terraform.io/docs/providers/google/r/compute_instance.html)
+  - [`google_compute_interconnect_attachment`](https://www.terraform.io/docs/providers/google/r/compute_interconnect_attachment.html)
   - [`google_compute_network`](https://www.terraform.io/docs/providers/google/r/compute_network.html)
+  - [`google_compute_network_peering`](https://www.terraform.io/docs/providers/google/r/compute_network_peering.html)
+  - [`google_compute_project_metadata_item`](https://www.terraform.io/docs/providers/google/r/compute_project_metadata_item.html)
+  - [`google_compute_region_backend_service`](https://www.terraform.io/docs/providers/google/r/compute_region_backend_service.html)
   - [`google_compute_router`](https://www.terraform.io/docs/providers/google/r/compute_router.html)
+  - [`google_compute_router_interface`](https://www.terraform.io/docs/providers/google/r/compute_router_interface.html)
   - [`google_compute_router_nat`](https://www.terraform.io/docs/providers/google/r/compute_router_nat.html)
+  - [`google_compute_router_peer`](https://www.terraform.io/docs/providers/google/r/compute_router_bgp_peer.html)
   - [`google_compute_shared_vpc_host_project`](https://www.terraform.io/docs/providers/google/r/compute_shared_vpc_host_project.html)
   - [`google_compute_shared_vpc_service_project`](https://www.terraform.io/docs/providers/google/r/compute_shared_vpc_service_project.html)
   - [`google_compute_subnetwork`](https://www.terraform.io/docs/providers/google/r/compute_subnetwork.html)
@@ -137,6 +172,37 @@ Terraform configs, including importing resources from within modules.
 - Service Networking
   - [`google_service_networking_connection`](https://www.terraform.io/docs/providers/google/r/service_networking_connection.html)
 
-### Random
+### [GSuite](https://github.com/DeviaVir/terraform-provider-gsuite)
 
-- [random_id](https://www.terraform.io/docs/providers/random/r/id.html)
+- [`gsuite_group`](https://github.com/DeviaVir/terraform-provider-gsuite/blob/master/gsuite/resource_group.go)
+- [`gsuite_group_member`](https://github.com/DeviaVir/terraform-provider-gsuite/blob/master/gsuite/resource_group_member.go)
+
+### [Helm](https://www.terraform.io/docs/providers/helm/index.html)
+
+- [`helm_release`](https://www.terraform.io/docs/providers/helm/r/release.html)
+
+### [Kubernetes](https://www.terraform.io/docs/providers/kubernetes/index.html)
+
+- [`kubernetes_config_map`](https://www.terraform.io/docs/providers/kubernetes/r/config_map.html)
+- [`kubernetes_namespace`](https://www.terraform.io/docs/providers/kubernetes/r/namespace.html)
+- [`kubernetes_pod`](https://www.terraform.io/docs/providers/kubernetes/r/pod.html)
+- [`kubernetes_role`](https://www.terraform.io/docs/providers/kubernetes/r/role.html)
+- [`kubernetes_role_binding`](https://www.terraform.io/docs/providers/kubernetes/r/role_binding.html)
+- [`kubernetes_service`](https://www.terraform.io/docs/providers/kubernetes/r/service.html)
+- [`kubernetes_service_account`](https://www.terraform.io/docs/providers/kubernetes/r/service_account.html)
+
+### [Random](https://www.terraform.io/docs/providers/random/index.html)
+
+- [`random_id`](https://www.terraform.io/docs/providers/random/r/id.html)
+- [`random_integer`](https://www.terraform.io/docs/providers/random/r/integer.html)
+
+## Resources Where Import Is Not Supported by Provider
+
+### Google
+
+- BigQuery
+  - [`google_bigquery_dataset_access`](https://www.terraform.io/docs/providers/google/r/bigquery_dataset_access.html)
+- Cloud Platform
+  - [`google_service_account_key`](https://www.terraform.io/docs/providers/google/r/google_service_account_key.html)
+- Cloud Storage
+  - [`google_storage_bucket_object`](https://www.terraform.io/docs/providers/google/r/storage_bucket_object.html)

--- a/cmd/tfimport/README.md
+++ b/cmd/tfimport/README.md
@@ -191,6 +191,10 @@ Terraform configs, including importing resources from within modules.
 - [`kubernetes_service`](https://www.terraform.io/docs/providers/kubernetes/r/service.html)
 - [`kubernetes_service_account`](https://www.terraform.io/docs/providers/kubernetes/r/service_account.html)
 
+### [Kubernetes Provider (Alpha)](https://github.com/hashicorp/terraform-provider-kubernetes-alpha)
+
+- [`kubernetes_manifest`](https://github.com/hashicorp/terraform-provider-kubernetes-alpha#create-a-kubernetes-custom-resource-definition)
+
 ### [Random](https://www.terraform.io/docs/providers/random/index.html)
 
 - [`random_id`](https://www.terraform.io/docs/providers/random/r/id.html)

--- a/cmd/tfimport/README.md
+++ b/cmd/tfimport/README.md
@@ -206,3 +206,22 @@ Terraform configs, including importing resources from within modules.
   - [`google_service_account_key`](https://www.terraform.io/docs/providers/google/r/google_service_account_key.html)
 - Cloud Storage
   - [`google_storage_bucket_object`](https://www.terraform.io/docs/providers/google/r/storage_bucket_object.html)
+
+### Local
+
+- [`local_file`](https://www.terraform.io/docs/providers/local/r/file.html)
+
+### Null
+
+- [`null_resource`](https://www.terraform.io/docs/providers/null/resource.html)
+
+### Random
+
+- [`random_password`](https://www.terraform.io/docs/providers/random/r/password.html)
+- [`random_pet`](https://www.terraform.io/docs/providers/random/r/pet.html)
+- [`random_shuffle`](https://www.terraform.io/docs/providers/random/r/shuffle.html)
+- [`random_string`](https://www.terraform.io/docs/providers/random/r/string.html)
+
+### TLS
+
+- [`tls_private_key`](https://www.terraform.io/docs/providers/tls/r/private_key.html)

--- a/cmd/tfimport/main.go
+++ b/cmd/tfimport/main.go
@@ -156,9 +156,9 @@ func planAndImport(rn, importRn runner.Runner) (retry bool, err error) {
 				cmd = err.Error()
 			} else {
 				// The last arg in import could be several space-separated strings. These need to be quoted together.
-				args := strings.Split(cmd, " ")
-				if len(args) >= 4 {
-					cmd = fmt.Sprintf("%v %v %v %q\n", args[0], args[1], args[2], strings.Join(args[3:], ""))
+				args := strings.SplitN(cmd, " ", 4)
+				if len(args) == 4 {
+					cmd = fmt.Sprintf("%v %v %v %q\n", args[0], args[1], args[2], args[3])
 				}
 			}
 

--- a/cmd/tfimport/main.go
+++ b/cmd/tfimport/main.go
@@ -151,7 +151,18 @@ func planAndImport(rn, importRn runner.Runner) (retry bool, err error) {
 
 		// In dry-run mode, the output is the command to run.
 		if *dryRun {
-			importCmds = append(importCmds, output)
+			cmd := output
+			if err != nil {
+				cmd = err.Error()
+			} else {
+				// The last arg in import could be several space-separated strings. These need to be quoted together.
+				args := strings.Split(cmd, " ")
+				if len(args) >= 4 {
+					cmd = fmt.Sprintf("%v %v %v %q\n", args[0], args[1], args[2], strings.Join(args[3:], ""))
+				}
+			}
+
+			importCmds = append(importCmds, cmd)
 			continue
 		}
 
@@ -188,11 +199,7 @@ func planAndImport(rn, importRn runner.Runner) (retry bool, err error) {
 	if *dryRun && len(importCmds) > 0 {
 		log.Printf("Import commands:")
 		fmt.Printf("cd %v\n", *inputDir)
-		// The last arg in import could be several space-separated strings. These need to be quoted together.
-		for _, c := range importCmds {
-			args := strings.Split(c, " ")
-			fmt.Printf("%v %v %v %q\n", args[0], args[1], args[2], strings.Join(args[3:], " "))
-		}
+		fmt.Printf("%v\n", strings.Join(importCmds, "\n"))
 
 		return false, nil
 	}

--- a/internal/tfimport/importer/random_integer.go
+++ b/internal/tfimport/importer/random_integer.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package importer
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/GoogleCloudPlatform/healthcare-data-protection-suite/internal/terraform"
+)
+
+// RandomInteger defines a struct with the necessary information for a random_integer to be imported.
+type RandomInteger struct{}
+
+// ImportID returns the ID of the resource to use in importing.
+func (c *RandomInteger) ImportID(rc terraform.ResourceChange, pcv ConfigMap, interactive bool) (string, error) {
+	if !interactive {
+		return "", &InsufficientInfoErr{MissingFields: []string{"result"}}
+	}
+
+	// We can get most of the values without the user.
+	min, err := fromConfigValues("min", rc.Change.After)
+	if err != nil {
+		return "", err
+	}
+	max, err := fromConfigValues("max", rc.Change.After)
+	if err != nil {
+		return "", err
+	}
+
+	// Seed is optional.
+	seed, _ := fromConfigValues("seed", rc.Change.After)
+
+	// Ask the user for the result.
+	prompt := "Please enter the generated integer as the value for \"result\""
+	result, err := fromUser(os.Stdin, "result", prompt)
+	if err != nil {
+		return "", err
+	}
+
+	ret := fmt.Sprintf("%v,%v,%v", result, min, max)
+	if seed != nil && seed != "" {
+		ret = fmt.Sprintf("%v,%v", ret, seed)
+	}
+	return ret, nil
+}

--- a/internal/tfimport/importer/random_integer.go
+++ b/internal/tfimport/importer/random_integer.go
@@ -43,7 +43,8 @@ func (c *RandomInteger) ImportID(rc terraform.ResourceChange, pcv ConfigMap, int
 	}
 
 	// Seed is optional.
-	seed, _ := fromConfigValues("seed", rc.Change.After)
+	seed, seedErr := fromConfigValues("seed", rc.Change.After)
+	seedExists := seedErr == nil
 
 	// Ask the user for the result.
 	prompt := "Please enter the generated integer as the value for \"result\""
@@ -53,7 +54,7 @@ func (c *RandomInteger) ImportID(rc terraform.ResourceChange, pcv ConfigMap, int
 	}
 
 	ret := fmt.Sprintf("%v,%v,%v", result, min, max)
-	if seed != nil && seed != "" {
+	if seedExists {
 		ret = fmt.Sprintf("%v,%v", ret, seed)
 	}
 	return ret, nil

--- a/internal/tfimport/tfimport.go
+++ b/internal/tfimport/tfimport.go
@@ -29,9 +29,13 @@ var (
 	reDoesNotExist  = regexp.MustCompile(`(?i)Error:.*Cannot import non-existent.*object`)
 )
 
-var kubernetesNamespaceNameImporter = &importer.SimpleImporter{
+var kubernetesImporter = &importer.SimpleImporter{
 	Fields: []string{"metadata"},
 	Tmpl:   "{{or (index .metadata \"namespace\") \"default\"}}/{{.metadata.name}}",
+}
+var kubernetesAlphaImporter = &importer.SimpleImporter{
+	Fields: []string{"manifest"},
+	Tmpl:   "{{or (index .manifest.metadata \"namespace\") \"default\"}}/{{.manifest.metadata.name}}",
 }
 
 // Defines all supported resource importers
@@ -384,16 +388,20 @@ var importers = map[string]resourceImporter{
 	},
 
 	// Kubernetes provider
-	"kubernetes_config_map": kubernetesNamespaceNameImporter,
+	"kubernetes_config_map": kubernetesImporter,
 	"kubernetes_namespace": &importer.SimpleImporter{
 		Fields: []string{"metadata"},
 		Tmpl:   "{{.metadata.name}}",
 	},
-	"kubernetes_pod":             kubernetesNamespaceNameImporter,
-	"kubernetes_role":            kubernetesNamespaceNameImporter,
-	"kubernetes_role_binding":    kubernetesNamespaceNameImporter,
-	"kubernetes_service":         kubernetesNamespaceNameImporter,
-	"kubernetes_service_account": kubernetesNamespaceNameImporter,
+	"kubernetes_pod":             kubernetesImporter,
+	"kubernetes_role":            kubernetesImporter,
+	"kubernetes_role_binding":    kubernetesImporter,
+	"kubernetes_service":         kubernetesImporter,
+	"kubernetes_service_account": kubernetesImporter,
+
+	// Kubernetes generic provider (alpha)
+	// See https://github.com/hashicorp/terraform-provider-kubernetes-alpha
+	"kubernetes_manifest": kubernetesAlphaImporter,
 
 	// Random provider
 	"random_id":      &importer.RandomID{},

--- a/internal/tfimport/tfimport.go
+++ b/internal/tfimport/tfimport.go
@@ -29,89 +29,121 @@ var (
 	reDoesNotExist  = regexp.MustCompile(`(?i)Error:.*Cannot import non-existent.*object`)
 )
 
+var kubernetesNamespaceNameImporter = &importer.SimpleImporter{
+	Fields: []string{"metadata"},
+	Tmpl:   "{{or (index .metadata \"namespace\") \"default\"}}/{{.metadata.name}}",
+}
+
 // Defines all supported resource importers
-// TODO: Add more resources
 var importers = map[string]resourceImporter{
-	"random_id": &importer.RandomID{},
-	"google_storage_bucket": &importer.SimpleImporter{
-		Fields: []string{"project", "name"},
-		Tmpl:   "{{.project}}/{{.name}}",
-	},
-	"google_container_cluster": &importer.SimpleImporter{
-		Fields: []string{"project", "location", "name"},
-		Tmpl:   "projects/{{.project}}/locations/{{.location}}/clusters/{{.name}}",
-	},
-	"google_organization_policy": &importer.SimpleImporter{
-		Fields: []string{"org_id", "constraint"},
-		Tmpl:   "{{.org_id}}/{{.constraint}}",
-	},
-	"google_organization_iam_member": &importer.SimpleImporter{
-		Fields: []string{"org_id", "role", "member"},
-		Tmpl:   "{{.org_id}} {{.role}} {{.member}}",
-	},
-	"google_organization_iam_audit_config": &importer.SimpleImporter{
-		Fields: []string{"org_id", "service"},
-		Tmpl:   "{{.org_id}} {{.service}}",
-	},
-	"google_project": &importer.SimpleImporter{
-		Fields: []string{"project_id"},
-		Tmpl:   "{{.project_id}}",
-	},
-	"google_project_iam_binding": &importer.SimpleImporter{
-		Fields: []string{"project", "role"},
-		Tmpl:   "{{.project}} {{.role}}",
-	},
-	"google_project_iam_member": &importer.SimpleImporter{
-		Fields: []string{"project", "role", "member"},
-		Tmpl:   "{{.project}} {{.role}} {{.member}}",
-	},
-	"google_project_service": &importer.SimpleImporter{
-		Fields: []string{"project", "service"},
-		Tmpl:   "{{.project}}/{{.service}}",
-	},
-	"google_service_account": &importer.SimpleImporter{
-		Fields: []string{"project", "account_id"},
-		Tmpl:   "projects/{{.project}}/serviceAccounts/{{.account_id}}@{{.project}}.iam.gserviceaccount.com",
-	},
-	"google_bigquery_table": &importer.SimpleImporter{
-		Fields: []string{"project", "dataset_id", "table_id"},
-		Tmpl:   "{{.project}}/{{.dataset_id}}/{{.table_id}}",
+	// Google provider
+	"google_app_engine_application": &importer.SimpleImporter{
+		Fields: []string{"project"},
+		Tmpl:   "{{.project}}",
 	},
 	"google_bigquery_dataset": &importer.SimpleImporter{
 		Fields: []string{"project", "dataset_id"},
 		Tmpl:   "projects/{{.project}}/datasets/{{.dataset_id}}",
 	},
-	"google_storage_bucket_iam_member": &importer.SimpleImporter{
-		Fields: []string{"bucket", "role", "member"},
-		Tmpl:   "{{.bucket}} {{.role}} {{.member}}",
+	"google_bigquery_table": &importer.SimpleImporter{
+		Fields: []string{"project", "dataset_id", "table_id"},
+		Tmpl:   "{{.project}}/{{.dataset_id}}/{{.table_id}}",
+	},
+	"google_billing_account_iam_binding": &importer.SimpleImporter{
+		Fields: []string{"billing_account_id", "role"},
+		Tmpl:   "{{.billing_account_id}} {{.role}}",
+	},
+	"google_billing_account_iam_member": &importer.SimpleImporter{
+		Fields: []string{"billing_account_id", "role", "member"},
+		Tmpl:   "{{.billing_account_id}} {{.role}} {{.member}}",
+	},
+	"google_billing_account_iam_policy": &importer.SimpleImporter{
+		Fields: []string{"billing_account_id"},
+		Tmpl:   "{{.billing_account_id}}",
+	},
+	"google_binary_authorization_policy": &importer.SimpleImporter{
+		Fields: []string{"project"},
+		Tmpl:   "projects/{{.project}}",
 	},
 	"google_cloudbuild_trigger": &importer.SimpleImporter{
 		Fields: []string{"project", "name"},
 		Tmpl:   "projects/{{.project}}/triggers/{{.name}}",
 	},
-	"google_logging_organization_sink": &importer.SimpleImporter{
-		Fields: []string{"org_id", "name"},
-		Tmpl:   "organizations/{{.org_id}}/sinks/{{.name}}",
+	"google_compute_address": &importer.SimpleImporter{
+		Fields: []string{"project", "region", "name"},
+		Tmpl:   "projects/{{.project}}/regions/{{.region}}/addresses/{{.name}}",
+	},
+	"google_compute_firewall": &importer.SimpleImporter{
+		Fields: []string{"project", "name"},
+		Tmpl:   "projects/{{.project}}/global/firewalls/{{.name}}",
+	},
+	"google_compute_forwarding_rule": &importer.SimpleImporter{
+		Fields: []string{"project", "region", "name"},
+		Tmpl:   "projects/{{.project}}/regions/{{.region}}/forwardingRules/{{.name}}",
+	},
+	"google_compute_global_address": &importer.SimpleImporter{
+		Fields: []string{"project", "name"},
+		Tmpl:   "projects/{{.project}}/global/addresses/{{.name}}",
+	},
+	"google_compute_health_check": &importer.SimpleImporter{
+		Fields: []string{"project", "name"},
+		Tmpl:   "projects/{{.project}}/global/healthChecks/{{.name}}",
+	},
+	"google_compute_image": &importer.SimpleImporter{
+		Fields: []string{"project", "name"},
+		Tmpl:   "projects/{{.project}}/global/images/{{.name}}",
+	},
+	"google_compute_instance_from_template": &importer.SimpleImporter{
+		Fields: []string{"project", "zone", "name"},
+		Tmpl:   "projects/{{.project}}/zones/{{.zone}}/instances/{{.name}}",
+	},
+	"google_compute_interconnect_attachment": &importer.SimpleImporter{
+		Fields: []string{"project", "region", "name"},
+		Tmpl:   "projects/{{.project}}/regions/{{.region}}/interconnectAttachments/{{.name}}",
 	},
 	"google_compute_network": &importer.SimpleImporter{
 		Fields: []string{"project", "name"},
 		Tmpl:   "projects/{{.project}}/global/networks/{{.name}}",
 	},
-	"google_compute_subnetwork": &importer.SimpleImporter{
+	"google_compute_network_peering": &importer.SimpleImporter{
+		Fields: []string{"network", "name"},
+		Tmpl:   "{{.network}}/{{.name}}",
+	},
+	"google_compute_project_metadata_item": &importer.SimpleImporter{
+		Fields: []string{"key"},
+		Tmpl:   "{{.key}}",
+	},
+	"google_compute_region_backend_service": &importer.SimpleImporter{
 		Fields: []string{"project", "region", "name"},
-		Tmpl:   "projects/{{.project}}/regions/{{.region}}/subnetworks/{{.name}}",
+		Tmpl:   "projects/{{.project}}/regions/{{.region}}/backendServices/{{.name}}",
 	},
 	"google_compute_router": &importer.SimpleImporter{
 		Fields: []string{"project", "region", "name"},
 		Tmpl:   "projects/{{.project}}/regions/{{.region}}/routers/{{.name}}",
 	},
+	"google_compute_router_interface": &importer.SimpleImporter{
+		Fields: []string{"region", "router", "name"},
+		Tmpl:   "{{.region}}/{{.router}}/{{.name}}",
+	},
 	"google_compute_router_nat": &importer.SimpleImporter{
 		Fields: []string{"project", "region", "router", "name"},
 		Tmpl:   "projects/{{.project}}/regions/{{.region}}/routers/{{.router}}/{{.name}}",
 	},
-	"google_compute_subnetwork_iam_policy": &importer.SimpleImporter{
-		Fields: []string{"subnetwork"},
-		Tmpl:   "{{.subnetwork}}",
+	"google_compute_router_peer": &importer.SimpleImporter{
+		Fields: []string{"project", "region", "router", "name"},
+		Tmpl:   "projects/{{.project}}/regions/{{.region}}/routers/{{.router}}/{{.name}}",
+	},
+	"google_compute_shared_vpc_host_project": &importer.SimpleImporter{
+		Fields: []string{"project"},
+		Tmpl:   "{{.project}}",
+	},
+	"google_compute_shared_vpc_service_project": &importer.SimpleImporter{
+		Fields: []string{"host_project", "service_project"},
+		Tmpl:   "{{.host_project}}/{{.service_project}}",
+	},
+	"google_compute_subnetwork": &importer.SimpleImporter{
+		Fields: []string{"project", "region", "name"},
+		Tmpl:   "projects/{{.project}}/regions/{{.region}}/subnetworks/{{.name}}",
 	},
 	"google_compute_subnetwork_iam_binding": &importer.SimpleImporter{
 		Fields: []string{"subnetwork", "role"},
@@ -120,6 +152,18 @@ var importers = map[string]resourceImporter{
 	"google_compute_subnetwork_iam_member": &importer.SimpleImporter{
 		Fields: []string{"subnetwork", "role", "member"},
 		Tmpl:   "{{.subnetwork}} {{.role}} {{.member}}",
+	},
+	"google_compute_subnetwork_iam_policy": &importer.SimpleImporter{
+		Fields: []string{"subnetwork"},
+		Tmpl:   "{{.subnetwork}}",
+	},
+	"google_container_cluster": &importer.SimpleImporter{
+		Fields: []string{"project", "location", "name"},
+		Tmpl:   "projects/{{.project}}/locations/{{.location}}/clusters/{{.name}}",
+	},
+	"google_container_node_pool": &importer.SimpleImporter{
+		Fields: []string{"project", "location", "cluster", "name"},
+		Tmpl:   "{{.project}}/{{.location}}/{{.cluster}}/{{.name}}",
 	},
 	"google_dns_managed_zone": &importer.SimpleImporter{
 		Fields: []string{"project", "name"},
@@ -133,21 +177,134 @@ var importers = map[string]resourceImporter{
 		Fields: []string{"project"},
 		Tmpl:   "projects/{{.project}}",
 	},
+	"google_folder": &importer.SimpleImporter{
+		// The user will always be asked for this, it cannot be automatically detemrined.
+		Fields: []string{"folder_id"},
+		Tmpl:   "folders/${folder_id}",
+	},
+	"google_folder_iam_binding": &importer.SimpleImporter{
+		Fields: []string{"folder", "role"},
+		Tmpl:   "{{.folder}} {{.role}}",
+	},
+	"google_folder_iam_member": &importer.SimpleImporter{
+		Fields: []string{"folder", "role", "member"},
+		Tmpl:   "{{.folder}} {{.role}} {{.member}}",
+	},
+	"google_folder_iam_policy": &importer.SimpleImporter{
+		Fields: []string{"folder"},
+		Tmpl:   "{{.folder}}",
+	},
+	"google_folder_organization_policy": &importer.SimpleImporter{
+		Fields: []string{"folder", "constraint"},
+		Tmpl:   "folders/{{.folder}}/constraints/{{.constraint}}",
+	},
+	"google_iap_tunnel_instance_iam_binding": &importer.SimpleImporter{
+		Fields: []string{"project", "zone", "instance", "role"},
+		Tmpl:   "projects/{{.project}}/iap_tunnel/zones/{{.zone}}/instances/{{.instance}} {{.role}}",
+	},
+	"google_iap_tunnel_instance_iam_member": &importer.SimpleImporter{
+		Fields: []string{"project", "zone", "instance", "role", "member"},
+		Tmpl:   "projects/{{.project}}/iap_tunnel/zones/{{.zone}}/instances/{{.instance}} {{.role}} {{.member}}",
+	},
+	"google_iap_tunnel_instance_iam_policy": &importer.SimpleImporter{
+		Fields: []string{"project", "zone", "instance"},
+		Tmpl:   "projects/{{.project}}/iap_tunnel/zones/{{.zone}}/instances/{{.instance}}",
+	},
+	"google_kms_key_ring": &importer.SimpleImporter{
+		Fields: []string{"project", "location", "name"},
+		Tmpl:   "projects/{{.project}}/locations/{{.location}}/keyRings/{{.name}}",
+	},
+	"google_logging_billing_account_sink": &importer.SimpleImporter{
+		Fields: []string{"billing_account", "name"},
+		Tmpl:   "billingAccounts/{{.billing_account}}/sinks/{{.name}}",
+	},
+	"google_logging_folder_sink": &importer.SimpleImporter{
+		Fields: []string{"folder", "name"},
+		Tmpl:   "folders/{{.folder}}/{{.name}}/",
+	},
+	"google_logging_organization_sink": &importer.SimpleImporter{
+		Fields: []string{"org_id", "name"},
+		Tmpl:   "organizations/{{.org_id}}/sinks/{{.name}}",
+	},
+	"google_logging_project_sink": &importer.SimpleImporter{
+		Fields: []string{"project", "name"},
+		Tmpl:   "projects/{{.project}}/sinks/{{.name}}",
+	},
+	"google_organization_iam_audit_config": &importer.SimpleImporter{
+		Fields: []string{"org_id", "service"},
+		Tmpl:   "{{.org_id}} {{.service}}",
+	},
+	"google_organization_iam_custom_role": &importer.SimpleImporter{
+		Fields: []string{"org_id", "role_id"},
+		Tmpl:   "organizations/{{.org_id}}/roles/{{.role_id}}",
+	},
+	"google_organization_iam_member": &importer.SimpleImporter{
+		Fields: []string{"org_id", "role", "member"},
+		Tmpl:   "{{.org_id}} {{.role}} {{.member}}",
+	},
+	"google_organization_policy": &importer.SimpleImporter{
+		Fields: []string{"org_id", "constraint"},
+		Tmpl:   "{{.org_id}}/{{.constraint}}",
+	},
+	"google_project": &importer.SimpleImporter{
+		Fields: []string{"project_id"},
+		Tmpl:   "{{.project_id}}",
+	},
+	"google_project_iam_binding": &importer.SimpleImporter{
+		Fields: []string{"project", "role"},
+		Tmpl:   "{{.project}} {{.role}}",
+	},
 	"google_project_iam_custom_role": &importer.SimpleImporter{
 		Fields: []string{"project", "role_id"},
 		Tmpl:   "projects/{{.project}}/roles/{{.role_id}}",
 	},
-	"google_container_node_pool": &importer.SimpleImporter{
-		Fields: []string{"project", "location", "cluster", "name"},
-		Tmpl:   "{{.project}}/{{.location}}/{{.cluster}}/{{.name}}",
+	"google_project_iam_member": &importer.SimpleImporter{
+		Fields: []string{"project", "role", "member"},
+		Tmpl:   "{{.project}} {{.role}} {{.member}}",
+	},
+	"google_project_organization_policy": &importer.SimpleImporter{
+		Fields: []string{"project", "constraint"},
+		Tmpl:   "project/{{.project}}:constraints/{{.constraint}}",
+	},
+	"google_project_service": &importer.SimpleImporter{
+		Fields: []string{"project", "service"},
+		Tmpl:   "{{.project}}/{{.service}}",
+	},
+	"google_project_usage_export_bucket": &importer.SimpleImporter{
+		Fields: []string{"project"},
+		Tmpl:   "{{.project}}",
+	},
+	"google_pubsub_subscription": &importer.SimpleImporter{
+		Fields: []string{"project", "name"},
+		Tmpl:   "projects/{{.project}}/subscriptions/{{.name}}",
+	},
+	"google_pubsub_subscription_iam_binding": &importer.SimpleImporter{
+		Fields: []string{"project", "subscription", "role"},
+		Tmpl:   "projects/{{.project}}/subscriptions/{{.subscription}} {{.role}}",
+	},
+	"google_pubsub_subscription_iam_member": &importer.SimpleImporter{
+		Fields: []string{"project", "subscription", "role", "member"},
+		Tmpl:   "projects/{{.project}}/subscriptions/{{.subscription}} {{.role}} {{.member}}",
+	},
+	"google_pubsub_subscription_iam_policy": &importer.SimpleImporter{
+		Fields: []string{"project", "subscription"},
+		Tmpl:   "projects/{{.project}}/subscriptions/{{.subscription}}",
 	},
 	"google_pubsub_topic": &importer.SimpleImporter{
 		Fields: []string{"project", "name"},
 		Tmpl:   "projects/{{.project}}/topics/{{.name}}",
 	},
-	"google_pubsub_subscription": &importer.SimpleImporter{
-		Fields: []string{"project", "name"},
-		Tmpl:   "projects/{{.project}}/subscriptions/{{.name}}",
+	"google_pubsub_topic_iam_binding": &importer.SimpleImporter{
+		Fields: []string{"project", "topic", "role"},
+		Tmpl:   "projects/{{.project}}/topics/{{.topic}} {{.role}}",
+	},
+	"google_pubsub_topic_iam_member": &importer.SimpleImporter{
+		Fields: []string{"project", "topic", "role", "member"},
+		Tmpl:   "projects/{{.project}}/topics/{{.topic}} {{.role}} {{.member}}",
+	},
+	"google_pubsub_topic_iam_policy": &importer.SimpleImporter{
+		Fields: []string{"project", "topic"},
+		Tmpl:   "projects/{{.project}}/topics/{{.topic}}",
 	},
 	"google_secret_manager_secret": &importer.SimpleImporter{
 		Fields: []string{"project", "secret_id"},
@@ -158,11 +315,9 @@ var importers = map[string]resourceImporter{
 		Fields: []string{"secret"},
 		Tmpl:   "{{.secret}}/versions/latest",
 	},
-	"google_service_account_iam_policy": &importer.SimpleImporter{
-		// This already includes the project. It looks like this:
-		// projects/my-network-project/serviceAccounts/my-sa@my-network-project.iam.gserviceaccount.com
-		Fields: []string{"service_account_id"},
-		Tmpl:   "{{.service_account_id}}",
+	"google_service_account": &importer.SimpleImporter{
+		Fields: []string{"project", "account_id"},
+		Tmpl:   "projects/{{.project}}/serviceAccounts/{{.account_id}}@{{.project}}.iam.gserviceaccount.com",
 	},
 	"google_service_account_iam_binding": &importer.SimpleImporter{
 		// This already includes the project. It looks like this:
@@ -176,6 +331,12 @@ var importers = map[string]resourceImporter{
 		Fields: []string{"service_account_id", "role", "member"},
 		Tmpl:   "{{.service_account_id}} {{.role}} {{.member}}",
 	},
+	"google_service_account_iam_policy": &importer.SimpleImporter{
+		// This already includes the project. It looks like this:
+		// projects/my-network-project/serviceAccounts/my-sa@my-network-project.iam.gserviceaccount.com
+		Fields: []string{"service_account_id"},
+		Tmpl:   "{{.service_account_id}}",
+	},
 	"google_service_networking_connection": &importer.ServiceNetworkingConnection{},
 	"google_sql_database": &importer.SimpleImporter{
 		Fields: []string{"project", "instance", "name"},
@@ -186,46 +347,57 @@ var importers = map[string]resourceImporter{
 		Tmpl:   "projects/{{.project}}/instances/{{.name}}",
 	},
 	"google_sql_user": &importer.SQLUser{},
-	"google_iap_tunnel_instance_iam_policy": &importer.SimpleImporter{
-		Fields: []string{"project", "zone", "instance"},
-		Tmpl:   "projects/{{.project}}/iap_tunnel/zones/{{.zone}}/instances/{{.instance}}",
-	},
-	"google_iap_tunnel_instance_iam_binding": &importer.SimpleImporter{
-		Fields: []string{"project", "zone", "instance", "role"},
-		Tmpl:   "projects/{{.project}}/iap_tunnel/zones/{{.zone}}/instances/{{.instance}} {{.role}}",
-	},
-	"google_iap_tunnel_instance_iam_member": &importer.SimpleImporter{
-		Fields: []string{"project", "zone", "instance", "role", "member"},
-		Tmpl:   "projects/{{.project}}/iap_tunnel/zones/{{.zone}}/instances/{{.instance}} {{.role}} {{.member}}",
-	},
-	"google_binary_authorization_policy": &importer.SimpleImporter{
-		Fields: []string{"project"},
-		Tmpl:   "projects/{{.project}}",
-	},
-	"google_compute_firewall": &importer.SimpleImporter{
+	"google_storage_bucket": &importer.SimpleImporter{
 		Fields: []string{"project", "name"},
-		Tmpl:   "projects/{{.project}}/global/firewalls/{{.name}}",
+		Tmpl:   "{{.project}}/{{.name}}",
 	},
-	"google_compute_global_address": &importer.SimpleImporter{
-		Fields: []string{"project", "name"},
-		Tmpl:   "projects/{{.project}}/global/addresses/{{.name}}",
+	"google_storage_bucket_iam_binding": &importer.SimpleImporter{
+		Fields: []string{"bucket", "role"},
+		Tmpl:   "{{.bucket}} {{.role}}",
 	},
-	"google_compute_image": &importer.SimpleImporter{
-		Fields: []string{"project", "name"},
-		Tmpl:   "projects/{{.project}}/global/images/{{.name}}",
+	"google_storage_bucket_iam_member": &importer.SimpleImporter{
+		Fields: []string{"bucket", "role", "member"},
+		Tmpl:   "{{.bucket}} {{.role}} {{.member}}",
 	},
-	"google_compute_instance_from_template": &importer.SimpleImporter{
-		Fields: []string{"project", "zone", "name"},
-		Tmpl:   "projects/{{.project}}/zones/{{.zone}}/instances/{{.name}}",
+	"google_storage_bucket_iam_policy": &importer.SimpleImporter{
+		Fields: []string{"bucket"},
+		Tmpl:   "{{.bucket}}",
 	},
-	"google_compute_shared_vpc_host_project": &importer.SimpleImporter{
-		Fields: []string{"project"},
-		Tmpl:   "{{.project}}",
+
+	// GSuite provider
+	"gsuite_group": &importer.SimpleImporter{
+		Fields: []string{"email"},
+		Tmpl:   "{{.email}}",
 	},
-	"google_compute_shared_vpc_service_project": &importer.SimpleImporter{
-		Fields: []string{"host_project", "service_project"},
-		Tmpl:   "{{.host_project}}/{{.service_project}}",
+	"gsuite_group_member": &importer.SimpleImporter{
+		Fields: []string{"group", "email"},
+		Tmpl:   "{{.group}}:{{.email}}",
 	},
+
+	// Helm provider
+	"helm_release": &importer.SimpleImporter{
+		Fields: []string{"namespace", "name"},
+		Tmpl:   "{{.namespace}}/{{.name}}",
+		Defaults: map[string]interface{}{
+			"namespace": "default",
+		},
+	},
+
+	// Kubernetes provider
+	"kubernetes_config_map": kubernetesNamespaceNameImporter,
+	"kubernetes_namespace": &importer.SimpleImporter{
+		Fields: []string{"metadata"},
+		Tmpl:   "{{.metadata.name}}",
+	},
+	"kubernetes_pod":             kubernetesNamespaceNameImporter,
+	"kubernetes_role":            kubernetesNamespaceNameImporter,
+	"kubernetes_role_binding":    kubernetesNamespaceNameImporter,
+	"kubernetes_service":         kubernetesNamespaceNameImporter,
+	"kubernetes_service_account": kubernetesNamespaceNameImporter,
+
+	// Random provider
+	"random_id":      &importer.RandomID{},
+	"random_integer": &importer.RandomInteger{},
 }
 
 // Resource represents a resource and an importer that can import it.


### PR DESCRIPTION
This list was generated the following way:
1. Run the engine on the full example.
2. Change all backends to "local".
3. Run init to download all modules into .terraform/ folders.
4. Grep for all unique "resource" declarations and filter out ones in `tfimport.go`.

I will add this script to the CI in a follow-up PR.

WANT_LGTM=all