### PR TITLE
always set activate_apis

### DIFF
--- a/templates/tfengine/components/project/project/main.tf
+++ b/templates/tfengine/components/project/project/main.tf
@@ -38,7 +38,7 @@ module "project" {
   {{- end}}
 
   activate_apis = [
-    {{- range .apis}}
+    {{- range get . "apis"}}
     "{{.}}",
     {{- end}}
   ]

--- a/templates/tfengine/components/project/project/main.tf
+++ b/templates/tfengine/components/project/project/main.tf
@@ -37,13 +37,11 @@ module "project" {
   ]
   {{- end}}
 
-  {{- if has . "apis"}}
   activate_apis = [
     {{- range .apis}}
     "{{.}}",
     {{- end}}
   ]
-  {{- end}}
 }
 
 {{if get . "is_shared_vpc_host" -}}


### PR DESCRIPTION
The CFT module has a weird default of ["compute.googleapis.com"] so if you ever set any api then suddenly compute api tries to get removed which causes a lot of hassles.