### PR TITLE
Merge engine and policygen schema logic for org policies

### DIFF
--- a/internal/policygen/load.go
+++ b/internal/policygen/load.go
@@ -40,12 +40,12 @@ type config struct {
 }
 
 func ValidateOrgPoliciesConfig(conf map[string]interface{}, allowAdditionalProperties bool) error {
-	schema := orgPoliciesSchema
+	s := orgPoliciesSchema
 	if !allowAdditionalProperties {
-		schema = append(schema, []byte("additionalProperties = false")...)
+		s = append(s, []byte("additionalProperties = false")...)
 	}
 
-	sj, err := hcl.ToJSON(schema)
+	sj, err := hcl.ToJSON(s)
 	if err != nil {
 		return err
 	}

--- a/internal/policygen/load.go
+++ b/internal/policygen/load.go
@@ -40,11 +40,12 @@ type config struct {
 }
 
 func ValidateOrgPoliciesConfig(conf map[string]interface{}, allowAdditionalProperties bool) error {
+	schema := orgPoliciesSchema
 	if !allowAdditionalProperties {
-		orgPoliciesSchema = append(orgPoliciesSchema, []byte("additionalProperties = false")...)
+		schema = append(schema, []byte("additionalProperties = false")...)
 	}
 
-	sj, err := hcl.ToJSON(orgPoliciesSchema)
+	sj, err := hcl.ToJSON(schema)
 	if err != nil {
 		return err
 	}

--- a/internal/policygen/schema.go
+++ b/internal/policygen/schema.go
@@ -16,7 +16,7 @@ package policygen
 
 // TODO(https://github.com/golang/go/issues/35950): Move this to its own file.
 
-const schema = `
+var schema = []byte(`
 title = "Policy Generator Config Schema"
 additionalProperties = false
 required = ["template_dir"]
@@ -46,6 +46,7 @@ properties = {
           type = "string"
         }
       }
+
       allowed_policy_member_domains = {
         description = "The list of domains to allow users from, e.g. example.com"
         type = "array"
@@ -56,86 +57,91 @@ properties = {
     }
   }
 
-  gcp_org_policies = {
-    description = "Key value pairs configure Google Cloud Organization Policies."
-    type = "object"
-    additionalProperties = false
-    required = [
-      "parent_type",
-      "parent_id",
-      "allowed_policy_member_customer_ids",
-    ]
-    properties = {
-      parent_type = {
-        description = "Type of parent GCP resource to apply the policy: can be one of 'organization', 'folder', or 'project'."
-        type = "string"
-        pattern = "^organization|folder|project$"
-      }
+  gcp_org_policies = {}
+}
+`)
 
-      parent_id = {
-        description = <<EOF
-          ID of parent GCP resource to apply the policy: can be one of the organization ID,
-          folder ID, or project ID according to parent_type.
-        EOF
-        type = "string"
-        pattern = "^[0-9]{8,25}$"
-      }
+var orgPoliciesSchema = []byte(`
+title = "Google Cloud Organization Policies Config Schema"
+required = [
+  "parent_type",
+  "parent_id",
+  "allowed_policy_member_customer_ids",
+]
 
-      allowed_policy_member_customer_ids = {
-        description = <<EOF
-          See templates/policygen/org_policies/variables.tf. Must be specified to restrict domain
-          members that can be assigned IAM roles. Obtain the ID by following
-          https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains#retrieving_customer_id.
-        EOF
-        type = "array"
-        items = {
-          type = "string"
-        }
-      }
+properties = {
+  parent_type = {
+    description = "Type of parent GCP resource to apply the policy: can be one of 'organization', 'folder', or 'project'."
+    type = "string"
+    pattern = "^organization|folder|project$"
+  }
 
-      allowed_shared_vpc_host_projects = {
-        description = <<EOF
-          See templates/policygen/org_policies/variables.tf. If not specified, default to allow all.
-        EOF
-        type = "array"
-        items = {
-          type = "string"
-        }
-      }
-      allowed_trusted_image_projects = {
-        description = <<EOF
-          See templates/policygen/org_policies/variables.tf. If not specified, default to allow all.
-        EOF
-        type = "array"
-        items = {
-          type = "string"
-        }
-      }
-      allowed_public_vms = {
-        description = <<EOF
-          See templates/policygen/org_policies/variables.tf. If not specified, default to deny all.
-        EOF
-        type = "array"
-        items = {
-          type = "string"
-        }
-      }
-      allowed_ip_forwarding_vms = {
-        description = <<EOF
-          See templates/policygen/org_policies/variables.tf. If not specified, default to allow all.
-        EOF
-        type = "array"
-        items = {
-          type = "string"
-        }
-      }
-      disable_sa_key_creation = {
-        description = <<EOF
-          Whether or not to disable the creation of service account external keys. If not specified, default to true.
-        EOF
-        type = "boolean"
-      }
+  parent_id = {
+    description = <<EOF
+      ID of parent GCP resource to apply the policy: can be one of the organization ID,
+      folder ID, or project ID according to parent_type.
+    EOF
+    type = "string"
+    pattern = "^[0-9]{8,25}$"
+  }
+
+  allowed_policy_member_customer_ids = {
+    description = <<EOF
+      See templates/policygen/org_policies/variables.tf. Must be specified to restrict domain
+      members that can be assigned IAM roles. Obtain the ID by following
+      https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains#retrieving_customer_id.
+    EOF
+    type = "array"
+    items = {
+      type = "string"
     }
   }
+
+  allowed_shared_vpc_host_projects = {
+    description = <<EOF
+      See templates/policygen/org_policies/variables.tf. If not specified, default to allow all.
+    EOF
+    type = "array"
+    items = {
+      type = "string"
+    }
+  }
+
+  allowed_trusted_image_projects = {
+    description = <<EOF
+      See templates/policygen/org_policies/variables.tf. If not specified, default to allow all.
+    EOF
+    type = "array"
+    items = {
+      type = "string"
+    }
+  }
+
+  allowed_public_vms = {
+    description = <<EOF
+      See templates/policygen/org_policies/variables.tf. If not specified, default to deny all.
+    EOF
+    type = "array"
+    items = {
+      type = "string"
+    }
+  }
+
+  allowed_ip_forwarding_vms = {
+    description = <<EOF
+      See templates/policygen/org_policies/variables.tf. If not specified, default to allow all.
+    EOF
+    type = "array"
+    items = {
+      type = "string"
+    }
+  }
+
+  disable_sa_key_creation = {
+    description = <<EOF
+      Whether or not to disable the creation of service account external keys. If not specified, default to true.
+    EOF
+    type = "boolean"
+  }
 }
-`
+`)

--- a/templates/tfengine/recipes/org/org_policies.hcl
+++ b/templates/tfengine/recipes/org/org_policies.hcl
@@ -12,31 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(xingao): expand schema to all supported fields.
-schema = {
-  title = "Org Policies Recipe"
-  required = [
-    "allowed_policy_member_customer_ids"
-  ]
-  properties = {
-    parent_type = {
-      description = "Type of parent GCP resource to apply the policy: can be one of 'organization', 'folder', or 'project'."
-      type        = "string"
-      pattern     = "^organization|folder|project$"
-    }
-
-    allowed_policy_member_customer_ids = {
-      description = <<EOF
-        See templates/policygen/org_policies/variables.tf. Must be specified to restrict domainmembers that can be assigned IAM roles.
-        Obtain the ID by following https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains#retrieving_customer_id.
-      EOF
-      type = "array"
-      items = {
-        type = "string"
-      }
-    }
-  }
-}
+# Schema for Organization Policies are handled by policygen.ValidateOrgPoliciesConfig().
 
 template "terragrunt" {
   recipe_path = "../deployment/terragrunt.hcl"


### PR DESCRIPTION
Fixes #174 

The templating logic that read config and output to appropriate locations will stay in engine or policygen. The most important part is to avoid duplicating the schema.