### PR TITLE
Simplify project recipe

### DIFF
--- a/examples/tfengine/full.hcl
+++ b/examples/tfengine/full.hcl
@@ -159,7 +159,7 @@ template "folder_team1" {
 # Prod central networks project for team 1.
 template "project_networks" {
   recipe_path = "{{$recipes}}/project.hcl"
-  output_path = "./live/prod/team1"
+  output_path = "./live/prod/team1/example-prod-networks"
   data = {
     parent_type = "folder"
     project = {
@@ -241,7 +241,7 @@ EOF
 # Prod central data project for team 1.
 template "project_data" {
   recipe_path = "{{$recipes}}/project.hcl"
-  output_path = "./live/prod/team1"
+  output_path = "./live/prod/team1/example-prod-data"
   data = {
     parent_type = "folder"
     project = {
@@ -364,7 +364,7 @@ EOF
 # Prod central apps project for team 1.
 template "project_apps" {
   recipe_path = "{{$recipes}}/project.hcl"
-  output_path = "./live/prod/team1"
+  output_path = "./live/prod/team1/example-prod-apps"
   data = {
     parent_type = "folder"
     project = {
@@ -413,7 +413,7 @@ template "project_apps" {
 # Prod firebase project for team 1.
 template "project_firebase" {
   recipe_path = "{{$recipes}}/project.hcl"
-  output_path = "./live/prod/team1"
+  output_path = "./live/prod/team1/example-prod-firebase"
   data = {
     parent_type = "folder"
     project = {

--- a/templates/tfengine/recipes/project.hcl
+++ b/templates/tfengine/recipes/project.hcl
@@ -107,15 +107,9 @@ schema = {
   }
 }
 
-{{/* TODO(umairidris): Stop doing this */}}
-{{$base := ""}}
-{{if eq .parent_type "folder"}}
-{{$base = .project.project_id}}
-{{end}}
-
 template "terragrunt" {
   recipe_path = "./terragrunt_deployment.hcl"
-  output_path = "{{$base}}/project"
+  output_path = "./project"
   flatten {
     key = "project"
   }
@@ -139,7 +133,7 @@ template "terragrunt" {
 
 template "project" {
   component_path = "../components/project/project"
-  output_path    = "{{$base}}/project"
+  output_path    = "./project"
   flatten {
     key = "project"
   }
@@ -148,7 +142,7 @@ template "project" {
 {{range $name, $_ := get . "deployments"}}
 template "resources_{{$name}}" {
   recipe_path = "./resources.hcl"
-  output_path = "{{$base}}/{{$name}}"
+  output_path = "{{$name}}"
   flatten {
     key = "deployments"
   }


### PR DESCRIPTION
Make project directory structure simpler and more consistent with org. Now the user can set the project directory to whatever they like (it doesn't need to be project ID like it was before). Continue using project ID in our examples.