### PR TITLE
make folder output path consistent with project

### DIFF
--- a/examples/tfengine/full.hcl
+++ b/examples/tfengine/full.hcl
@@ -138,7 +138,7 @@ EOF
 # Top level prod folder.
 template "folder_prod" {
   recipe_path = "{{$recipes}}/folder.hcl"
-  output_path = "./live"
+  output_path = "./live/prod"
   data = {
     display_name = "prod"
   }
@@ -147,7 +147,7 @@ template "folder_prod" {
 # Prod folder for team 1.
 template "folder_team1" {
   recipe_path = "{{$recipes}}/folder.hcl"
-  output_path = "./live/prod"
+  output_path = "./live/prod/team1"
   data = {
     parent_type  = "folder"
     display_name = "team1"

--- a/templates/tfengine/recipes/folder.hcl
+++ b/templates/tfengine/recipes/folder.hcl
@@ -41,7 +41,7 @@ schema = {
 
 template "deployment" {
   recipe_path = "./deployment.hcl"
-  output_path = "{{.display_name}}/folder"
+  output_path = "./folder"
   data = {
     enable_terragrunt = true
     {{if eq .parent_type "folder"}}
@@ -63,7 +63,7 @@ template "deployment" {
 
 template "folder" {
   component_path = "../components/folder"
-  output_path    = "{{.display_name}}/folder"
+  output_path    = "./folder"
   data = {
     display_name = "{{.display_name}}"
     {{if eq .parent_type "organization"}}


### PR DESCRIPTION
We stopped adding a prefix for projects, so do the same for folders.