### PR TITLE
Fix the rule to ignore generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-**/generated linguist-generated=true
+**/generated/** linguist-generated=true


### PR DESCRIPTION
Looking at https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite/pull/338, it doesn't seem like the rule quite worked. Adjust it to match all files under the directory as well.