### PR TITLE
Run validate-all in engine tests

### DIFF
--- a/internal/tfengine/tfengine_test.go
+++ b/internal/tfengine/tfengine_test.go
@@ -56,10 +56,11 @@ func TestExamples(t *testing.T) {
 				t.Fatalf("ConvertToLocalBackend(%v): %v", path, err)
 			}
 
-			plan := exec.Command("terragrunt", "plan-all")
-			plan.Dir = path
-			if b, err := plan.CombinedOutput(); err != nil {
-				t.Errorf("command %v in %q: %v\n%v", plan.Args, path, err, string(b))
+			// Validate all configs, which will also run init everywhere.
+			validate := exec.Command("terragrunt", "validate-all")
+			validate.Dir = path
+			if b, err := validate.CombinedOutput(); err != nil {
+				t.Errorf("command %v in %q: %v\n%v", validate.Args, path, err, string(b))
 			}
 		})
 	}


### PR DESCRIPTION
This will also run init, like plan-all, but will additionally validate that the generated configs.