### PR TITLE
support fetch remote policies in policygen

### DIFF
--- a/cmd/tfengine/main.go
+++ b/cmd/tfengine/main.go
@@ -20,7 +20,9 @@ package main
 
 import (
 	"flag"
+	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/GoogleCloudPlatform/healthcare-data-protection-suite/internal/tfengine"
 )
@@ -29,7 +31,6 @@ var (
 	configPath = flag.String("config_path", "", "Path to config file")
 	outputPath = flag.String("output_path", "", "Path to directory dump output")
 	format     = flag.Bool("format", true, "Whether to format generated files.")
-	cacheDir   = flag.String("cache_dir", ".tfengine", "Path to directory to fetch remote templates.")
 )
 
 func main() {
@@ -42,7 +43,13 @@ func main() {
 		log.Fatal("--output_path must be set")
 	}
 
-	opts := &tfengine.Options{Format: *format, CacheDir: *cacheDir}
+	cacheDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(cacheDir)
+
+	opts := &tfengine.Options{Format: *format, CacheDir: cacheDir}
 	if err := tfengine.Run(*configPath, *outputPath, opts); err != nil {
 		log.Fatal(err)
 	}

--- a/docs/policygen/README.md
+++ b/docs/policygen/README.md
@@ -32,23 +32,38 @@ Currently supported Policy Libraries:
 
 ### Generate policies
 
-```shell
-# Step 1: Clone repo
-git clone https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite
-cd healthcare-data-protection-suite
+1. Download the latest
+    [policygen binary](https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite/releases)
+    or build one yourself:
 
-# Step 2: Setup helper env vars
-CONFIG_PATH=examples/policygen/config.hcl
-STATE_PATH=/path/to/your/tfstate
-OUTPUT_PATH=/tmp/policygen
+    ```shell
+    git clone https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite
+    cd healthcare-data-protection-suite
+    go install ./cmd/policygen
+    ```
 
-# Step 3: Install the policygen from the repo root
-go install ./cmd/policygen
+1. Set up helper environment variables:
 
-# Step 4: Generate policies. Edit config with values of your infra.
-# nano $CONFIG_PATH
-policygen --config_path=$CONFIG_PATH --state_path=$STATE_PATH --output_path=$OUTPUT_PATH
-```
+    ```shell
+    CONFIG_PATH=examples/policygen/config.hcl
+    STATE_PATH=/path/to/your/tfstate
+    OUTPUT_PATH=/tmp/policygen
+    ```
+
+1. Edit config with values of your infra:
+
+    TIP: Prefer to remotely fetch templates from a release which can be more
+    stable than using the HEAD templates. In your config:
+
+    ```hcl
+    template_dir = "git://github.com/GoogleCloudPlatform/healthcare-data-protection-suite//templates/policygen?ref=policies-v0.1.0"
+    ```
+
+1. Generate policies:
+
+    ```shell
+    policygen --config_path=$CONFIG_PATH --state_path=$STATE_PATH --output_path=$OUTPUT_PATH
+    ```
 
 `--state_path` supports a single local file, a local directory or a Google Cloud
 Storage bucket (indicated by `gs://` prefix).

--- a/examples/policygen/config.yaml
+++ b/examples/policygen/config.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-template_dir: ../../templates/policygen
+template_dir: "git://github.com/GoogleCloudPlatform/healthcare-data-protection-suite//templates/policygen?ref=policies-v0.1.0"
 
 gcp_org_policies:
   parent_type: organization # One of `organization`, `folder` or `project`

--- a/examples/tfengine/devops.hcl
+++ b/examples/tfengine/devops.hcl
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# {{$recipes := "../../templates/tfengine/recipes"}}
-
 data = {
   parent_type      = "organization" # One of `organization` or `folder`.
   parent_id        = "12345678"
@@ -22,7 +20,7 @@ data = {
 }
 
 template "devops" {
-  recipe_path = "{{$recipes}}/devops.hcl"
+  recipe_path = "git://github.com/GoogleCloudPlatform/healthcare-data-protection-suite//templates/tfengine/recipes/devops.hcl?ref=templates-v0.1.0"
   data = {
     # TODO(user): Uncomment and re-run the engine after generated bootstrap module has been deployed.
     # Run `terraform init` in the bootstrap module to backup its state to GCS.

--- a/internal/policygen/load.go
+++ b/internal/policygen/load.go
@@ -69,9 +69,6 @@ func loadConfig(path string) (*config, error) {
 		return nil, fmt.Errorf("read config %q: %v", path, err)
 	}
 
-	// Save unmodified path to use in init().
-	originalPath := path
-
 	// Convert yaml to json so hcl decoder can parse it.
 	if filepath.Ext(path) == ".yaml" {
 		b, err = yaml.YAMLToJSON(b)
@@ -89,14 +86,14 @@ func loadConfig(path string) (*config, error) {
 		return nil, err
 	}
 
-	if err := c.init(originalPath); err != nil {
+	if err := c.init(); err != nil {
 		return nil, err
 	}
 
 	return c, nil
 }
 
-func (c *config) init(path string) error {
+func (c *config) init() error {
 	var err error
 	if c.ForsetiPoliciesCty != nil {
 		c.ForsetiPolicies, err = hcl.CtyValueToMap(c.ForsetiPoliciesCty)
@@ -130,10 +127,6 @@ func (c *config) init(path string) error {
 		if err := ValidateOrgPoliciesConfig(c.GCPOrgPolicies); err != nil {
 			return err
 		}
-	}
-
-	if !filepath.IsAbs(c.TemplateDir) {
-		c.TemplateDir = filepath.Join(filepath.Dir(path), c.TemplateDir)
 	}
 
 	return nil


### PR DESCRIPTION
also just use a tmp dir for engine remote template cache

Fixes https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite/issues/233