### PR TITLE
check links

### DIFF
--- a/build/links_check.sh
+++ b/build/links_check.sh
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+
+set -e
+
+# Print versions
+npm version
+
+# Check links of all markdown files in docs.
+npm install -g markdown-link-check
+for f in $(find docs/ -name '*.md'); do markdown-link-check $f; done

--- a/build/presubmit.yaml
+++ b/build/presubmit.yaml
@@ -29,7 +29,7 @@ steps:
   waitFor: ["-"]
   id: Markdownlint check
 
-- me: "gcr.io/cloud-builders/npm:current"
+- name: "gcr.io/cloud-builders/npm:current"
   entrypoint: "bash"
   args: ["build/links_check.sh"]
   waitFor: ["-"]

--- a/build/presubmit.yaml
+++ b/build/presubmit.yaml
@@ -29,6 +29,12 @@ steps:
   waitFor: ["-"]
   id: Markdownlint check
 
+- me: "gcr.io/cloud-builders/npm:current"
+  entrypoint: "bash"
+  args: ["build/links_check.sh"]
+  waitFor: ["-"]
+  id: Links check
+
 - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools@sha256:02b06198f1da423183937b60493bdaa20dedf36b1a852a1d7fbb5a537fd943fd"
   entrypoint: "sh"
   args: ["build/go_check.sh"]


### PR DESCRIPTION
Only docs folder is checked to not slow down presubmits. Once pure terraform configs are checked in I will go through the whole dir fixing any broken links in components etc.

Fix #325 