### PR TITLE
Create empty output directories with no files

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,6 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
-github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -243,8 +241,6 @@ github.com/hashicorp/hil v0.0.0-20200423225030-a18a1cd20038 h1:n9J0rwVWXDpNd5iZn
 github.com/hashicorp/hil v0.0.0-20200423225030-a18a1cd20038/go.mod h1:n2TSygSNwsLJ76m8qFXTSc7beTb+auJxYdqrnoqwZWE=
 github.com/hashicorp/memberlist v0.1.0/go.mod h1:ncdBp14cuox2iFOq3kDiquKU6fqsTBc3W6JvZwjxxsE=
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
-github.com/hashicorp/terraform v0.12.28 h1:mBA+A9dvMXk1xDpflKEP5mL/KOD0sXap+M4F4Vlgnvc=
-github.com/hashicorp/terraform v0.12.28/go.mod h1:CBxNAiTW0pLap44/3GU4j7cYE2bMhkKZNlHPcr4P55U=
 github.com/hashicorp/terraform v0.12.29 h1:UkuApT6qh6KONIT1Jz7HoV8f4B+x71db3bmGcBzjBB0=
 github.com/hashicorp/terraform v0.12.29/go.mod h1:CBxNAiTW0pLap44/3GU4j7cYE2bMhkKZNlHPcr4P55U=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7/go.mod h1:p+ivJws3dpqbp1iP84+npOyAmTTOLMgCzrXd3GSdn/A=

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -50,7 +50,7 @@ func WriteDir(inputDir, outputDir string, data map[string]interface{}) error {
 	if len(fs) == 0 {
 		// Just create the output directory with no files.
 		if err := os.MkdirAll(outputDir, 0755); err != nil {
-			return fmt.Errorf("mkdir %q: %v", outputDir, err)
+			return fmt.Errorf("create dir %q: %v", outputDir, err)
 		}
 		return nil
 	}

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -48,7 +48,11 @@ func WriteDir(inputDir, outputDir string, data map[string]interface{}) error {
 		return fmt.Errorf("read dir %q: %v", inputDir, err)
 	}
 	if len(fs) == 0 {
-		return fmt.Errorf("found no files in %q to write", inputDir)
+		// Just create the output directory with no files.
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			return fmt.Errorf("mkdir %q: %v", outputDir, err)
+		}
+		return nil
 	}
 
 	for _, f := range fs {


### PR DESCRIPTION
No particular reason that this should be an error. Someone could use this to set up a directory structure (envs/, modules/) that they'll populate later.