### PR TITLE
Multiple actions

### DIFF
--- a/examples/tfengine/generated/devops/cicd/configs/run.sh
+++ b/examples/tfengine/generated/devops/cicd/configs/run.sh
@@ -17,17 +17,17 @@
 set -e
 set -x
 
-DIRS=(
+MODULES=(
 )
 
-ACTION="plan"
+ACTIONS=()
 ROOT="."
 
 while getopts "a:d:" c
 do
   case $c in
-    a) ACTION=${OPTARG} ;;
-    d) ROOT=${OPTARG} ;;
+    a) ACTIONS+=("${OPTARG}") ;;
+    d) ROOT="${OPTARG}" ;;
     *)
       echo "Invalid flag ${OPTARG}"
       exit 1
@@ -36,11 +36,14 @@ do
 done
 
 ROOT=$(realpath "${ROOT}")
-IFS=', ' read -r -a args <<< "${ACTION}"
 
-for d in "${DIRS[@]}"
+for mod in "${MODULES[@]}"
 do
-    cd "${ROOT}"/"${d}"
+    cd "${ROOT}"/"${mod}"
     terraform init
-    terraform "${args[@]}"
+    for action in "${ACTIONS[@]}"
+    do
+      IFS=', ' read -r -a args <<< "${action}"
+      terraform "${args[@]}"
+    done
 done

--- a/examples/tfengine/generated/devops/cicd/configs/run.sh
+++ b/examples/tfengine/generated/devops/cicd/configs/run.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-set -x
+set -ex
 
 MODULES=(
 )

--- a/examples/tfengine/generated/devops/cicd/configs/run.sh
+++ b/examples/tfengine/generated/devops/cicd/configs/run.sh
@@ -43,6 +43,7 @@ do
     terraform init
     for action in "${ACTIONS[@]}"
     do
+      # Convert action string to array as it can have multiple arguments.
       IFS=' ' read -r -a args <<< "${action}"
       terraform "${args[@]}"
     done

--- a/examples/tfengine/generated/devops/cicd/configs/run.sh
+++ b/examples/tfengine/generated/devops/cicd/configs/run.sh
@@ -43,7 +43,7 @@ do
     terraform init
     for action in "${ACTIONS[@]}"
     do
-      IFS=', ' read -r -a args <<< "${action}"
+      IFS=' ' read -r -a args <<< "${action}"
       terraform "${args[@]}"
     done
 done

--- a/examples/tfengine/generated/devops/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/devops/cicd/configs/tf-apply.yaml
@@ -22,7 +22,7 @@ steps:
 
   - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools@sha256:02b06198f1da423183937b60493bdaa20dedf36b1a852a1d7fbb5a537fd943fd"
     entrypoint: bash
-    args: ["./cicd/configs/run.sh", "-a", "apply -auto-approve"]
+    args: ["./cicd/configs/run.sh", "-a", "plan", "-a", "apply -auto-approve"]
     dir: "${_TERRAFORM_ROOT}"
     id: Apply
 

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/run.sh
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/run.sh
@@ -47,6 +47,7 @@ do
     terraform init
     for action in "${ACTIONS[@]}"
     do
+      # Convert action string to array as it can have multiple arguments.
       IFS=' ' read -r -a args <<< "${action}"
       terraform "${args[@]}"
     done

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/run.sh
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/run.sh
@@ -47,7 +47,7 @@ do
     terraform init
     for action in "${ACTIONS[@]}"
     do
-      IFS=', ' read -r -a args <<< "${action}"
+      IFS=' ' read -r -a args <<< "${action}"
       terraform "${args[@]}"
     done
 done

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/run.sh
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/run.sh
@@ -17,21 +17,21 @@
 set -e
 set -x
 
-DIRS=(
+MODULES=(
   audit
   monitor
   org_policies
   folders
 )
 
-ACTION="plan"
+ACTIONS=()
 ROOT="."
 
 while getopts "a:d:" c
 do
   case $c in
-    a) ACTION=${OPTARG} ;;
-    d) ROOT=${OPTARG} ;;
+    a) ACTIONS+=("${OPTARG}") ;;
+    d) ROOT="${OPTARG}" ;;
     *)
       echo "Invalid flag ${OPTARG}"
       exit 1
@@ -40,11 +40,14 @@ do
 done
 
 ROOT=$(realpath "${ROOT}")
-IFS=', ' read -r -a args <<< "${ACTION}"
 
-for d in "${DIRS[@]}"
+for mod in "${MODULES[@]}"
 do
-    cd "${ROOT}"/"${d}"
+    cd "${ROOT}"/"${mod}"
     terraform init
-    terraform "${args[@]}"
+    for action in "${ACTIONS[@]}"
+    do
+      IFS=', ' read -r -a args <<< "${action}"
+      terraform "${args[@]}"
+    done
 done

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/run.sh
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/run.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-set -x
+set -ex
 
 MODULES=(
   audit

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/tf-apply.yaml
@@ -22,7 +22,7 @@ steps:
 
   - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools@sha256:02b06198f1da423183937b60493bdaa20dedf36b1a852a1d7fbb5a537fd943fd"
     entrypoint: bash
-    args: ["./cicd/configs/run.sh", "-a", "apply -auto-approve"]
+    args: ["./cicd/configs/run.sh", "-a", "plan", "-a", "apply -auto-approve"]
     dir: "${_TERRAFORM_ROOT}"
     id: Apply
 

--- a/examples/tfengine/generated/org_foundation/cicd/configs/run.sh
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/run.sh
@@ -47,6 +47,7 @@ do
     terraform init
     for action in "${ACTIONS[@]}"
     do
+      # Convert action string to array as it can have multiple arguments.
       IFS=' ' read -r -a args <<< "${action}"
       terraform "${args[@]}"
     done

--- a/examples/tfengine/generated/org_foundation/cicd/configs/run.sh
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/run.sh
@@ -47,7 +47,7 @@ do
     terraform init
     for action in "${ACTIONS[@]}"
     do
-      IFS=', ' read -r -a args <<< "${action}"
+      IFS=' ' read -r -a args <<< "${action}"
       terraform "${args[@]}"
     done
 done

--- a/examples/tfengine/generated/org_foundation/cicd/configs/run.sh
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/run.sh
@@ -17,21 +17,21 @@
 set -e
 set -x
 
-DIRS=(
+MODULES=(
   audit
   monitor
   org_policies
   folders
 )
 
-ACTION="plan"
+ACTIONS=()
 ROOT="."
 
 while getopts "a:d:" c
 do
   case $c in
-    a) ACTION=${OPTARG} ;;
-    d) ROOT=${OPTARG} ;;
+    a) ACTIONS+=("${OPTARG}") ;;
+    d) ROOT="${OPTARG}" ;;
     *)
       echo "Invalid flag ${OPTARG}"
       exit 1
@@ -40,11 +40,14 @@ do
 done
 
 ROOT=$(realpath "${ROOT}")
-IFS=', ' read -r -a args <<< "${ACTION}"
 
-for d in "${DIRS[@]}"
+for mod in "${MODULES[@]}"
 do
-    cd "${ROOT}"/"${d}"
+    cd "${ROOT}"/"${mod}"
     terraform init
-    terraform "${args[@]}"
+    for action in "${ACTIONS[@]}"
+    do
+      IFS=', ' read -r -a args <<< "${action}"
+      terraform "${args[@]}"
+    done
 done

--- a/examples/tfengine/generated/org_foundation/cicd/configs/run.sh
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/run.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-set -x
+set -ex
 
 MODULES=(
   audit

--- a/examples/tfengine/generated/org_foundation/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/tf-apply.yaml
@@ -22,7 +22,7 @@ steps:
 
   - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools@sha256:02b06198f1da423183937b60493bdaa20dedf36b1a852a1d7fbb5a537fd943fd"
     entrypoint: bash
-    args: ["./cicd/configs/run.sh", "-a", "apply -auto-approve"]
+    args: ["./cicd/configs/run.sh", "-a", "plan", "-a", "apply -auto-approve"]
     dir: "${_TERRAFORM_ROOT}"
     id: Apply
 

--- a/examples/tfengine/generated/team/cicd/configs/run.sh
+++ b/examples/tfengine/generated/team/cicd/configs/run.sh
@@ -47,6 +47,7 @@ do
     terraform init
     for action in "${ACTIONS[@]}"
     do
+      # Convert action string to array as it can have multiple arguments.
       IFS=' ' read -r -a args <<< "${action}"
       terraform "${args[@]}"
     done

--- a/examples/tfengine/generated/team/cicd/configs/run.sh
+++ b/examples/tfengine/generated/team/cicd/configs/run.sh
@@ -47,7 +47,7 @@ do
     terraform init
     for action in "${ACTIONS[@]}"
     do
-      IFS=', ' read -r -a args <<< "${action}"
+      IFS=' ' read -r -a args <<< "${action}"
       terraform "${args[@]}"
     done
 done

--- a/examples/tfengine/generated/team/cicd/configs/run.sh
+++ b/examples/tfengine/generated/team/cicd/configs/run.sh
@@ -17,21 +17,21 @@
 set -e
 set -x
 
-DIRS=(
+MODULES=(
   example-prod-secrets
   example-prod-networks
   example-prod-data
   example-prod-apps
 )
 
-ACTION="plan"
+ACTIONS=()
 ROOT="."
 
 while getopts "a:d:" c
 do
   case $c in
-    a) ACTION=${OPTARG} ;;
-    d) ROOT=${OPTARG} ;;
+    a) ACTIONS+=("${OPTARG}") ;;
+    d) ROOT="${OPTARG}" ;;
     *)
       echo "Invalid flag ${OPTARG}"
       exit 1
@@ -40,11 +40,14 @@ do
 done
 
 ROOT=$(realpath "${ROOT}")
-IFS=', ' read -r -a args <<< "${ACTION}"
 
-for d in "${DIRS[@]}"
+for mod in "${MODULES[@]}"
 do
-    cd "${ROOT}"/"${d}"
+    cd "${ROOT}"/"${mod}"
     terraform init
-    terraform "${args[@]}"
+    for action in "${ACTIONS[@]}"
+    do
+      IFS=', ' read -r -a args <<< "${action}"
+      terraform "${args[@]}"
+    done
 done

--- a/examples/tfengine/generated/team/cicd/configs/run.sh
+++ b/examples/tfengine/generated/team/cicd/configs/run.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-set -x
+set -ex
 
 MODULES=(
   example-prod-secrets

--- a/examples/tfengine/generated/team/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/team/cicd/configs/tf-apply.yaml
@@ -22,7 +22,7 @@ steps:
 
   - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools@sha256:02b06198f1da423183937b60493bdaa20dedf36b1a852a1d7fbb5a537fd943fd"
     entrypoint: bash
-    args: ["./cicd/configs/run.sh", "-a", "apply -auto-approve"]
+    args: ["./cicd/configs/run.sh", "-a", "plan", "-a", "apply -auto-approve"]
     dir: "${_TERRAFORM_ROOT}"
     id: Apply
 

--- a/templates/tfengine/components/cicd/configs/run.sh
+++ b/templates/tfengine/components/cicd/configs/run.sh
@@ -46,6 +46,7 @@ do
     terraform init
     for action in "${ACTIONS[@]}"
     do
+      # Convert action string to array as it can have multiple arguments.
       IFS=' ' read -r -a args <<< "${action}"
       terraform "${args[@]}"
     done

--- a/templates/tfengine/components/cicd/configs/run.sh
+++ b/templates/tfengine/components/cicd/configs/run.sh
@@ -17,20 +17,20 @@
 set -e
 set -x
 
-DIRS=(
+MODULES=(
   {{- range .managed_modules}}
   {{.}}
   {{- end}}
 )
 
-ACTION="plan"
+ACTIONS=()
 ROOT="."
 
 while getopts "a:d:" c
 do
   case $c in
-    a) ACTION=${OPTARG} ;;
-    d) ROOT=${OPTARG} ;;
+    a) ACTIONS+=("${OPTARG}") ;;
+    d) ROOT="${OPTARG}" ;;
     *)
       echo "Invalid flag ${OPTARG}"
       exit 1
@@ -39,11 +39,14 @@ do
 done
 
 ROOT=$(realpath "${ROOT}")
-IFS=', ' read -r -a args <<< "${ACTION}"
 
-for d in "${DIRS[@]}"
+for mod in "${MODULES[@]}"
 do
-    cd "${ROOT}"/"${d}"
+    cd "${ROOT}"/"${mod}"
     terraform init
-    terraform "${args[@]}"
+    for action in "${ACTIONS[@]}"
+    do
+      IFS=', ' read -r -a args <<< "${action}"
+      terraform "${args[@]}"
+    done
 done

--- a/templates/tfengine/components/cicd/configs/run.sh
+++ b/templates/tfengine/components/cicd/configs/run.sh
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-set -x
+set -ex
 
 MODULES=(
   {{- range .managed_modules}}

--- a/templates/tfengine/components/cicd/configs/run.sh
+++ b/templates/tfengine/components/cicd/configs/run.sh
@@ -46,7 +46,7 @@ do
     terraform init
     for action in "${ACTIONS[@]}"
     do
-      IFS=', ' read -r -a args <<< "${action}"
+      IFS=' ' read -r -a args <<< "${action}"
       terraform "${args[@]}"
     done
 done

--- a/templates/tfengine/components/cicd/configs/tf-apply.yaml
+++ b/templates/tfengine/components/cicd/configs/tf-apply.yaml
@@ -22,7 +22,7 @@ steps:
 
   - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools@sha256:02b06198f1da423183937b60493bdaa20dedf36b1a852a1d7fbb5a537fd943fd"
     entrypoint: bash
-    args: ["./cicd/configs/run.sh", "-a", "apply -auto-approve"]
+    args: ["./cicd/configs/run.sh", "-a", "plan", "-a", "apply -auto-approve"]
     dir: "${_TERRAFORM_ROOT}"
     id: Apply
 


### PR DESCRIPTION
terraform apply -auto-approve does not show the plan, which can make things confusing when something goes wrong with one deployment. Show a plan before apply to be safe.