### PR TITLE
Allow Renovate Bot to update generated .tf files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "ignorePaths": []
 }


### PR DESCRIPTION
See this comment: https://github.com/renovatebot/config-help/issues/179#issuecomment-471319331

We were using the default value for ignorePath, which ignores `"**/examples/**"`.