### PR TITLE
Revert changes to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,5 @@
 {
   "extends": [
     "config:base"
-  ],
-  "ignorePaths": [],
-  "packageRules": [
-    {
-      "paths": ["*.tf"],
-      "groupName": "terraform"
-    }
   ]
 }


### PR DESCRIPTION
It seems like they didn't work as intended. Now Renovate Bot only updates examples/ but not templates/.

I've asked some questions in https://github.com/renovatebot/config-help/issues/782 and will experiment locally before putting up a new PR.