### PR TITLE
Correct regex match field according to docs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,13 +5,15 @@
   "ignorePaths": [],
   "packageRules": [
     {
-      "managers": ["terraform"],
-      "groupName": "terraform",
-      "fileMatch": [
-        "\\.tf$"
-      ],
+      "managers": ["regex", "terraform"],
+      "groupName": "terraform"
+    }
+  ],
+  "fileMatch": ["\\.tf$"],
+  "regexManagers": [
+    {
       "matchStrings": [
-        "source\\s+=\\s+\"(?<depName>.+?)\"\\s+version\\s+=\\s+\"(?<currentValue>.+?)\""
+        "source\\s+=\\s+\"(?<depName>.+?)(//.+|\")\\s+version\\s+=\\s+\"(?<currentValue>.+?)\""
       ],
       "datasourceTemplate": "terraform-module",
       "versioningTemplate": "hashicorp"


### PR DESCRIPTION
Changes made since last time:
* Target the "regex" manager in the packageRules rule.
* Put `fileMatch` at the top level, where it should be.
* Put `regexManagers` at the top level, where it should be.
* Adjust the regex to handle both deps with submodules (`//`) and without.

The regex was tested against these files via [regex101](https://regex101.com/):
* https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite/blob/master/examples/tfengine/generated/team/example-prod-apps/main.tf
* https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite/blob/master/templates/tfengine/components/resources/gke_clusters/main.tf