### PR TITLE
Revert "fix(renovate): match .tf files only for terraform manager"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,9 +9,7 @@
       "groupName": "terraform"
     }
   ],
-  "terraform": {
-    "fileMatch": ["\\.tf$"]
-  },
+  "fileMatch": ["\\.tf$"],
   "regexManagers": [
     {
       "matchStrings": [


### PR DESCRIPTION
Reverts GoogleCloudPlatform/healthcare-data-protection-suite#604

I think this PR might have been responsible for why the gen_check is failing in https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite/pull/610. It only updated one of the files, and not the other one.

I'm going to revert it, as things were working before.