### PR TITLE
fix(renovate): add fileMatch to regex manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,11 +9,9 @@
       "groupName": "terraform"
     }
   ],
-  "terraform": {
-    "fileMatch": ["\\.tf$"]
-  },
   "regexManagers": [
     {
+      "fileMatch": ["\\.tf$"],
       "matchStrings": [
         "source\\s+=\\s+\"(?<depName>.+?)(//.+|\")\\s+version\\s+=\\s+\"(?<currentValue>.+?)\""
       ],


### PR DESCRIPTION
Adds missing `fileMatch` field to regex manager and removes unnecessary terraform fileMatch.