### PR TITLE
Fix Forseti for 0.13

### DIFF
--- a/docs/tfengine/schemas/monitor.md
+++ b/docs/tfengine/schemas/monitor.md
@@ -34,12 +34,6 @@ Name of the bastion host's network.
 
 Type: string
 
-### forseti.network_project_id
-
-Name of network project. If unset, will use the current project.
-
-Type: string
-
 ### forseti.security_command_center_source_id
 
 Security Command Center (SCC) Source ID used for Forseti notification.
@@ -69,12 +63,6 @@ Type: string
 Config of project to host monitoring resources
 
 Type: object
-
-### project.project_id
-
-ID of project.
-
-Type: string
 
 ### storage_location
 

--- a/docs/tfengine/schemas/monitor.md
+++ b/docs/tfengine/schemas/monitor.md
@@ -28,6 +28,18 @@ Domain for the Forseti instance.
 
 Type: string
 
+### forseti.network
+
+Name of the bastion host's network.
+
+Type: string
+
+### forseti.network_project_id
+
+Name of network project. If unset, will use the current project.
+
+Type: string
+
 ### forseti.security_command_center_source_id
 
 Security Command Center (SCC) Source ID used for Forseti notification.
@@ -43,6 +55,12 @@ and obtain the SCC source ID;
 
 3) Add the ID through this field, generate the Terraform configs and
 deploy Forseti again.
+
+Type: string
+
+### forseti.subnet
+
+Name of the bastion host's subnet.
 
 Type: string
 

--- a/docs/tfengine/schemas/monitor.md
+++ b/docs/tfengine/schemas/monitor.md
@@ -30,7 +30,7 @@ Type: string
 
 ### forseti.network
 
-Name of the bastion host's network.
+Name of the Forseti network.
 
 Type: string
 
@@ -54,7 +54,7 @@ Type: string
 
 ### forseti.subnet
 
-Name of the bastion host's subnet.
+Name of the Forseti subnet.
 
 Type: string
 

--- a/examples/tfengine/folder_foundation.hcl
+++ b/examples/tfengine/folder_foundation.hcl
@@ -152,10 +152,12 @@ template "monitor" {
   data = {
     project = {
       project_id = "example-monitor"
+      shared_vpc_attachment = {
+        host_project_id = "example-prod-networks"
+      }
     }
     forseti = {
       domain             = "example.com"
-      network_project_id = "example-prod-networks"
       network            = "network"
       subnet             = "forseti-subnet"
     }

--- a/examples/tfengine/folder_foundation.hcl
+++ b/examples/tfengine/folder_foundation.hcl
@@ -131,7 +131,7 @@ template "project_networks" {
       }]
       compute_routers = [{
         name    = "forseti-router"
-        network = "$${module.network.network.network.self_link}"
+        network = "$${module.example_network.network.network.self_link}"
         nats = [{
           name                               = "forseti-nat"
           source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"

--- a/examples/tfengine/folder_foundation.hcl
+++ b/examples/tfengine/folder_foundation.hcl
@@ -121,7 +121,7 @@ template "project_networks" {
     }
     resources = {
       compute_networks = [{
-        name = "network"
+        name = "example-network"
         subnets = [
           {
             name     = "forseti-subnet"

--- a/examples/tfengine/generated/folder_foundation/example-prod-networks/main.tf
+++ b/examples/tfengine/generated/folder_foundation/example-prod-networks/main.tf
@@ -42,11 +42,11 @@ module "project" {
   activate_apis                  = ["compute.googleapis.com"]
 }
 
-module "network" {
+module "example_network" {
   source  = "terraform-google-modules/network/google"
   version = "~> 2.5.0"
 
-  network_name = "network"
+  network_name = "example-network"
   project_id   = module.project.project_id
 
   subnets = [
@@ -67,7 +67,7 @@ module "forseti_router" {
   name    = "forseti-router"
   project = module.project.project_id
   region  = "us-central1"
-  network = module.network.network.network.self_link
+  network = module.example_network.network.network.self_link
 
   nats = [
     {

--- a/examples/tfengine/generated/folder_foundation/example-prod-networks/main.tf
+++ b/examples/tfengine/generated/folder_foundation/example-prod-networks/main.tf
@@ -1,0 +1,86 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = "~> 0.12.0"
+  required_providers {
+    google      = "~> 3.0"
+    google-beta = "~> 3.0"
+  }
+  backend "gcs" {
+    bucket = "example-terraform-state"
+    prefix = "example-prod-networks"
+  }
+}
+
+# Create the project and optionally enable APIs, create the deletion lien and add to shared VPC.
+# Deletion lien: https://cloud.google.com/resource-manager/docs/project-liens
+# Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
+module "project" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 9.2.0"
+
+  name                           = "example-prod-networks"
+  org_id                         = ""
+  folder_id                      = "12345678"
+  billing_account                = "000-000-000"
+  lien                           = true
+  default_service_account        = "keep"
+  skip_gcloud_download           = true
+  enable_shared_vpc_host_project = true
+  activate_apis                  = ["compute.googleapis.com"]
+}
+
+module "network" {
+  source  = "terraform-google-modules/network/google"
+  version = "~> 2.5.0"
+
+  network_name = "network"
+  project_id   = module.project.project_id
+
+  subnets = [
+    {
+      subnet_name           = "forseti-subnet"
+      subnet_ip             = "10.1.0.0/16"
+      subnet_region         = "us-central1"
+      subnet_flow_logs      = true
+      subnet_private_access = true
+    },
+  ]
+}
+
+module "forseti_router" {
+  source  = "terraform-google-modules/cloud-router/google"
+  version = "~> 0.3.0"
+
+  name    = "forseti-router"
+  project = module.project.project_id
+  region  = "us-central1"
+  network = module.network.network.network.self_link
+
+  nats = [
+    {
+      name                               = "forseti-nat"
+      source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+
+      subnetworks = [
+        {
+          name                     = "${module.example_network.subnets["us-central1/forseti-subnet"].self_link}"
+          source_ip_ranges_to_nat  = ["PRIMARY_IP_RANGE"]
+          secondary_ip_range_names = []
+        },
+      ]
+    },
+  ]
+}

--- a/examples/tfengine/generated/folder_foundation/example-prod-networks/outputs.tf
+++ b/examples/tfengine/generated/folder_foundation/example-prod-networks/outputs.tf
@@ -1,0 +1,21 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "project_id" {
+  value = module.project.project_id
+}
+
+output "project_number" {
+  value = module.project.project_number
+}

--- a/examples/tfengine/generated/folder_foundation/monitor/main.tf
+++ b/examples/tfengine/generated/folder_foundation/monitor/main.tf
@@ -28,7 +28,7 @@ terraform {
 # Deletion lien: https://cloud.google.com/resource-manager/docs/project-liens
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
-  source  = "terraform-google-modules/project-factory/google"
+  source  = "terraform-google-modules/project-factory/google//modules/shared_vpc"
   version = "~> 9.2.0"
 
   name                    = "example-monitor"
@@ -38,7 +38,9 @@ module "project" {
   lien                    = true
   default_service_account = "keep"
   skip_gcloud_download    = true
-  activate_apis           = []
+
+  shared_vpc    = "example-prod-networks"
+  activate_apis = []
 }
 
 

--- a/examples/tfengine/generated/org_foundation/cicd/configs/run.sh
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/run.sh
@@ -19,6 +19,7 @@ set -ex
 MODULES=(
   devops
   audit
+  example-prod-networks
   monitor
   org_policies
   folders

--- a/examples/tfengine/generated/org_foundation/example-prod-networks/main.tf
+++ b/examples/tfengine/generated/org_foundation/example-prod-networks/main.tf
@@ -41,11 +41,11 @@ module "project" {
   activate_apis                  = ["compute.googleapis.com"]
 }
 
-module "network" {
+module "example_network" {
   source  = "terraform-google-modules/network/google"
   version = "~> 2.5.0"
 
-  network_name = "network"
+  network_name = "example-network"
   project_id   = module.project.project_id
 
   subnets = [
@@ -66,7 +66,7 @@ module "forseti_router" {
   name    = "forseti-router"
   project = module.project.project_id
   region  = "us-central1"
-  network = module.network.network.network.self_link
+  network = module.example_network.network.network.self_link
 
   nats = [
     {

--- a/examples/tfengine/generated/org_foundation/example-prod-networks/main.tf
+++ b/examples/tfengine/generated/org_foundation/example-prod-networks/main.tf
@@ -1,0 +1,85 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = "~> 0.12.0"
+  required_providers {
+    google      = "~> 3.0"
+    google-beta = "~> 3.0"
+  }
+  backend "gcs" {
+    bucket = "example-terraform-state"
+    prefix = "example-prod-networks"
+  }
+}
+
+# Create the project and optionally enable APIs, create the deletion lien and add to shared VPC.
+# Deletion lien: https://cloud.google.com/resource-manager/docs/project-liens
+# Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
+module "project" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 9.2.0"
+
+  name                           = "example-prod-networks"
+  org_id                         = "12345678"
+  billing_account                = "000-000-000"
+  lien                           = true
+  default_service_account        = "keep"
+  skip_gcloud_download           = true
+  enable_shared_vpc_host_project = true
+  activate_apis                  = ["compute.googleapis.com"]
+}
+
+module "network" {
+  source  = "terraform-google-modules/network/google"
+  version = "~> 2.5.0"
+
+  network_name = "network"
+  project_id   = module.project.project_id
+
+  subnets = [
+    {
+      subnet_name           = "forseti-subnet"
+      subnet_ip             = "10.1.0.0/16"
+      subnet_region         = "us-central1"
+      subnet_flow_logs      = true
+      subnet_private_access = true
+    },
+  ]
+}
+
+module "forseti_router" {
+  source  = "terraform-google-modules/cloud-router/google"
+  version = "~> 0.3.0"
+
+  name    = "forseti-router"
+  project = module.project.project_id
+  region  = "us-central1"
+  network = module.network.network.network.self_link
+
+  nats = [
+    {
+      name                               = "forseti-nat"
+      source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+
+      subnetworks = [
+        {
+          name                     = "${module.example_network.subnets["us-central1/forseti-subnet"].self_link}"
+          source_ip_ranges_to_nat  = ["PRIMARY_IP_RANGE"]
+          secondary_ip_range_names = []
+        },
+      ]
+    },
+  ]
+}

--- a/examples/tfengine/generated/org_foundation/example-prod-networks/outputs.tf
+++ b/examples/tfengine/generated/org_foundation/example-prod-networks/outputs.tf
@@ -1,0 +1,21 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "project_id" {
+  value = module.project.project_id
+}
+
+output "project_number" {
+  value = module.project.project_number
+}

--- a/examples/tfengine/generated/org_foundation/monitor/main.tf
+++ b/examples/tfengine/generated/org_foundation/monitor/main.tf
@@ -40,57 +40,17 @@ module "project" {
   activate_apis           = []
 }
 
-locals {
-  forseti_vpc_name    = "forseti-vpc"
-  forseti_subnet_name = "forseti-subnet"
-  forseti_subnet_key  = "us-central1/${local.forseti_subnet_name}"
-}
-
-# TODO(xingao): fix the data dependency in Forseti CloudSQL sub module
-# https://github.com/forseti-security/terraform-google-forseti/blob/master/modules/cloudsql/main.tf
-# and reuse the network component instead of putting putting the network here.
-module "network" {
-  source  = "terraform-google-modules/network/google"
-  version = "~> 2.1"
-
-  project_id   = module.project.project_id
-  network_name = local.forseti_vpc_name
-  subnets = [{
-    subnet_name   = local.forseti_subnet_name
-    subnet_ip     = "10.10.10.0/24"
-    subnet_region = "us-central1"
-  }]
-}
-
-module "router" {
-  source  = "terraform-google-modules/cloud-router/google"
-  version = "~> 0.3.0"
-
-  name    = "forseti-router"
-  project = module.project.project_id
-  region  = "us-central1"
-  network = module.network.network_name
-
-  nats = [{
-    name                               = "forseti-nat"
-    source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
-    subnetworks = [{
-      name                     = module.network.subnets[local.forseti_subnet_key].self_link
-      source_ip_ranges_to_nat  = ["PRIMARY_IP_RANGE"]
-      secondary_ip_range_names = []
-    }]
-  }]
-}
 
 module "forseti" {
   source  = "terraform-google-modules/forseti/google"
   version = "~> 5.2.1"
 
-  domain     = "example.com"
-  project_id = module.project.project_id
-  org_id     = "12345678"
-  network    = module.network.network_name
-  subnetwork = module.network.subnets[local.forseti_subnet_key].name
+  domain          = "example.com"
+  project_id      = module.project.project_id
+  org_id          = "12345678"
+  network_project = "example-prod-networks"
+  network         = "network"
+  subnetwork      = "forseti-subnet"
   composite_root_resources = [
     "organizations/12345678",
   ]

--- a/examples/tfengine/generated/org_foundation/monitor/main.tf
+++ b/examples/tfengine/generated/org_foundation/monitor/main.tf
@@ -28,7 +28,7 @@ terraform {
 # Deletion lien: https://cloud.google.com/resource-manager/docs/project-liens
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
-  source  = "terraform-google-modules/project-factory/google"
+  source  = "terraform-google-modules/project-factory/google//modules/shared_vpc"
   version = "~> 9.2.0"
 
   name                    = "example-monitor"
@@ -37,7 +37,9 @@ module "project" {
   lien                    = true
   default_service_account = "keep"
   skip_gcloud_download    = true
-  activate_apis           = []
+
+  shared_vpc    = "example-prod-networks"
+  activate_apis = []
 }
 
 

--- a/examples/tfengine/org_foundation.hcl
+++ b/examples/tfengine/org_foundation.hcl
@@ -141,10 +141,12 @@ template "monitor" {
   data = {
     project = {
       project_id = "example-monitor"
+      shared_vpc_attachment = {
+        host_project_id = "example-prod-networks"
+      }
     }
     forseti = {
       domain             = "example.com"
-      network_project_id = "example-prod-networks"
       network            = "network"
       subnet             = "forseti-subnet"
     }

--- a/examples/tfengine/org_foundation.hcl
+++ b/examples/tfengine/org_foundation.hcl
@@ -120,7 +120,7 @@ template "project_networks" {
       }]
       compute_routers = [{
         name    = "forseti-router"
-        network = "$${module.network.network.network.self_link}"
+        network = "$${module.example_network.network.network.self_link}"
         nats = [{
           name                               = "forseti-nat"
           source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"

--- a/examples/tfengine/org_foundation.hcl
+++ b/examples/tfengine/org_foundation.hcl
@@ -71,6 +71,7 @@ template "cicd" {
     managed_dirs = [
       "devops", // NOTE: CICD service account can only update APIs on the devops project.
       "audit",
+      "example-prod-networks",
       "monitor",
       "org_policies",
       "folders",
@@ -95,6 +96,45 @@ template "audit" {
   }
 }
 
+# Prod central networks project for team 1.
+template "project_networks" {
+  recipe_path = "{{$recipes}}/project.hcl"
+  output_path = "./example-prod-networks"
+  data = {
+    project = {
+      project_id         = "example-prod-networks"
+      is_shared_vpc_host = true
+      apis = [
+        "compute.googleapis.com",
+      ]
+    }
+    resources = {
+      compute_networks = [{
+        name = "network"
+        subnets = [
+          {
+            name     = "forseti-subnet"
+            ip_range = "10.1.0.0/16"
+          },
+        ]
+      }]
+      compute_routers = [{
+        name    = "forseti-router"
+        network = "$${module.network.network.network.self_link}"
+        nats = [{
+          name                               = "forseti-nat"
+          source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+          subnetworks = [{
+            name                     = "$${module.example_network.subnets[\"us-central1/forseti-subnet\"].self_link}"
+            source_ip_ranges_to_nat  = ["PRIMARY_IP_RANGE"]
+            secondary_ip_range_names = []
+          }]
+        }]
+      }]
+    }
+  }
+}
+
 template "monitor" {
   recipe_path = "{{$recipes}}/monitor.hcl"
   output_path = "./monitor"
@@ -103,7 +143,10 @@ template "monitor" {
       project_id = "example-monitor"
     }
     forseti = {
-      domain = "example.com"
+      domain             = "example.com"
+      network_project_id = "example-prod-networks"
+      network            = "network"
+      subnet             = "forseti-subnet"
     }
   }
 }

--- a/examples/tfengine/org_foundation.hcl
+++ b/examples/tfengine/org_foundation.hcl
@@ -110,7 +110,7 @@ template "project_networks" {
     }
     resources = {
       compute_networks = [{
-        name = "network"
+        name = "example-network"
         subnets = [
           {
             name     = "forseti-subnet"

--- a/internal/tfengine/integration_test.go
+++ b/internal/tfengine/integration_test.go
@@ -67,6 +67,7 @@ func runPlanOnDeployments(t *testing.T, dir string) {
 	skipDirs := map[string]bool{
 		"cicd":       true,
 		"kubernetes": true,
+		"monitor":    true, // TODO(umairidris): don't skip this dir once we switch off Forseti
 	}
 	for _, f := range fs {
 		if !f.IsDir() || skipDirs[f.Name()] {

--- a/templates/tfengine/recipes/monitor.hcl
+++ b/templates/tfengine/recipes/monitor.hcl
@@ -19,13 +19,6 @@ schema = {
     project = {
       description          = "Config of project to host monitoring resources"
       type                 = "object"
-      additionalProperties = false
-      properties = {
-        project_id = {
-          description = "ID of project."
-          type        = "string"
-        }
-      }
     }
     forseti = {
       description          = "Config for the Forseti instance."
@@ -34,10 +27,6 @@ schema = {
       properties = {
         domain = {
           description = "Domain for the Forseti instance."
-          type        = "string"
-        }
-        network_project_id = {
-          description = "Name of network project. If unset, will use the current project."
           type        = "string"
         }
         network = {
@@ -89,6 +78,9 @@ template "project" {
 
 template "forseti" {
   component_path = "../components/monitor/forseti"
+  data = {
+    network_project_id = "{{.project.shared_vpc_attachment.host_project_id}}"
+  }
   flatten {
     key = "forseti"
   }

--- a/templates/tfengine/recipes/monitor.hcl
+++ b/templates/tfengine/recipes/monitor.hcl
@@ -36,6 +36,18 @@ schema = {
           description = "Domain for the Forseti instance."
           type        = "string"
         }
+        network_project_id = {
+          description = "Name of network project. If unset, will use the current project."
+          type        = "string"
+        }
+        network = {
+          description = "Name of the bastion host's network."
+          type        = "string"
+        }
+        subnet = {
+          description = "Name of the bastion host's subnet."
+          type        = "string"
+        }
         security_command_center_source_id = {
           description = <<EOF
             Security Command Center (SCC) Source ID used for Forseti notification.

--- a/templates/tfengine/recipes/monitor.hcl
+++ b/templates/tfengine/recipes/monitor.hcl
@@ -30,11 +30,11 @@ schema = {
           type        = "string"
         }
         network = {
-          description = "Name of the bastion host's network."
+          description = "Name of the Forseti network."
           type        = "string"
         }
         subnet = {
-          description = "Name of the bastion host's subnet."
+          description = "Name of the Forseti subnet."
           type        = "string"
         }
         security_command_center_source_id = {


### PR DESCRIPTION
Don't create network in monitor project, instead use the shared vpc host project to create its network. This is how it should be anyway, but since monitoring was done before networking we didn't migrate it over until now.

Now that the network and forseti instance are created in two different deployments it should work. Note that the initial plan will fail until the network project has been created.