### PR TITLE
rm compute service account field on gke cluster

### DIFF
--- a/examples/tfengine/app.hcl
+++ b/examples/tfengine/app.hcl
@@ -274,7 +274,6 @@ EOF
             ip_range_pods_name     = "example-pods-range"
             ip_range_services_name = "example-services-range"
             master_ipv4_cidr_block = "192.168.0.0/28"
-            service_account        = "gke@example-prod-apps.iam.gserviceaccount.com"
             labels = {
               type = "no-phi"
             }

--- a/examples/tfengine/generated/app/modules/project_apps/main.tf
+++ b/examples/tfengine/generated/app/modules/project_apps/main.tf
@@ -103,16 +103,15 @@ module "example_gke_cluster" {
   regional           = true
   network_project_id = "example-prod-networks"
 
-  network                        = "example-network"
-  subnetwork                     = "example-gke-subnet"
-  ip_range_pods                  = "example-pods-range"
-  ip_range_services              = "example-services-range"
-  master_ipv4_cidr_block         = "192.168.0.0/28"
-  istio                          = true
-  skip_provisioners              = true
-  enable_private_endpoint        = false
-  release_channel                = "STABLE"
-  compute_engine_service_account = "gke@example-prod-apps.iam.gserviceaccount.com"
+  network                 = "example-network"
+  subnetwork              = "example-gke-subnet"
+  ip_range_pods           = "example-pods-range"
+  ip_range_services       = "example-services-range"
+  master_ipv4_cidr_block  = "192.168.0.0/28"
+  istio                   = true
+  skip_provisioners       = true
+  enable_private_endpoint = false
+  release_channel         = "STABLE"
   cluster_resource_labels = {
     type = "no-phi"
   }


### PR DESCRIPTION
The current config doesn't work. Setting the service account field requires the user to create the SA. By omitting it, the module will create its own SA for the cluster.