### PR TITLE
always create app engine app in cicd

### DIFF
--- a/examples/tfengine/devops.hcl
+++ b/examples/tfengine/devops.hcl
@@ -50,14 +50,14 @@ template "cicd" {
       owner = "GoogleCloudPlatform"
       name  = "example"
     }
-    terraform_root = "terraform"
 
-    # Required to create Cloud Scheduler jobs.
+    # Required for scheduler.
     scheduler_region = "us-east1"
 
     build_viewers = ["group:example-cicd-viewers@example.com"]
     build_editors = ["group:example-cicd-editors@example.com"]
 
+    terraform_root = "terraform"
     envs = [
       {
         name        = "prod"

--- a/examples/tfengine/folder_foundation.hcl
+++ b/examples/tfengine/folder_foundation.hcl
@@ -56,7 +56,7 @@ template "cicd" {
       name  = "example"
     }
 
-    # Required to create Cloud Scheduler jobs.
+    # Required for scheduler.
     scheduler_region = "us-east1"
 
     build_viewers = ["group:example-cicd-viewers@example.com"]

--- a/examples/tfengine/generated/devops/cicd/main.tf
+++ b/examples/tfengine/generated/devops/cicd/main.tf
@@ -141,6 +141,7 @@ resource "google_project_iam_member" "cloudbuild_sa_project_iam" {
 
 # Cloud Scheduler resources.
 # Cloud Scheduler requires an App Engine app created in the project.
+# App Engine app cannot be destroyed once created, therefore always create it.
 resource "google_app_engine_application" "cloudbuild_scheduler_app" {
   project     = var.project_id
   location_id = "us-east1"

--- a/examples/tfengine/generated/folder_foundation/cicd/main.tf
+++ b/examples/tfengine/generated/folder_foundation/cicd/main.tf
@@ -139,6 +139,7 @@ resource "google_project_iam_member" "cloudbuild_sa_project_iam" {
 
 # Cloud Scheduler resources.
 # Cloud Scheduler requires an App Engine app created in the project.
+# App Engine app cannot be destroyed once created, therefore always create it.
 resource "google_app_engine_application" "cloudbuild_scheduler_app" {
   project     = var.project_id
   location_id = "us-east1"

--- a/examples/tfengine/generated/multi_envs/cicd/main.tf
+++ b/examples/tfengine/generated/multi_envs/cicd/main.tf
@@ -163,6 +163,17 @@ resource "google_project_iam_member" "cloudbuild_sa_project_iam" {
   ]
 }
 
+# Cloud Scheduler resources.
+# Cloud Scheduler requires an App Engine app created in the project.
+# App Engine app cannot be destroyed once created, therefore always create it.
+resource "google_app_engine_application" "cloudbuild_scheduler_app" {
+  project     = var.project_id
+  location_id = "us-east1"
+  depends_on = [
+    google_project_service.services,
+  ]
+}
+
 
 
 # Cloud Build - Cloud Build Service Account IAM permissions

--- a/examples/tfengine/generated/org_foundation/cicd/main.tf
+++ b/examples/tfengine/generated/org_foundation/cicd/main.tf
@@ -137,6 +137,17 @@ resource "google_project_iam_member" "cloudbuild_sa_project_iam" {
   ]
 }
 
+# Cloud Scheduler resources.
+# Cloud Scheduler requires an App Engine app created in the project.
+# App Engine app cannot be destroyed once created, therefore always create it.
+resource "google_app_engine_application" "cloudbuild_scheduler_app" {
+  project     = var.project_id
+  location_id = "us-east1"
+  depends_on = [
+    google_project_service.services,
+  ]
+}
+
 
 
 # Cloud Build - Cloud Build Service Account IAM permissions

--- a/examples/tfengine/generated/team/cicd/main.tf
+++ b/examples/tfengine/generated/team/cicd/main.tf
@@ -135,6 +135,17 @@ resource "google_project_iam_member" "cloudbuild_sa_project_iam" {
   ]
 }
 
+# Cloud Scheduler resources.
+# Cloud Scheduler requires an App Engine app created in the project.
+# App Engine app cannot be destroyed once created, therefore always create it.
+resource "google_app_engine_application" "cloudbuild_scheduler_app" {
+  project     = var.project_id
+  location_id = "us-east1"
+  depends_on = [
+    google_project_service.services,
+  ]
+}
+
 
 
 # Cloud Build - Cloud Build Service Account IAM permissions

--- a/examples/tfengine/multi_envs.hcl
+++ b/examples/tfengine/multi_envs.hcl
@@ -61,7 +61,7 @@ template "cicd" {
       ]
     }
 
-    # Required to create Cloud Scheduler jobs.
+    # Required for scheduler.
     scheduler_region = "us-east1"
 
     build_viewers = ["group:example-cicd-viewers@example.com"]

--- a/examples/tfengine/org_foundation.hcl
+++ b/examples/tfengine/org_foundation.hcl
@@ -55,10 +55,14 @@ template "cicd" {
       owner = "GoogleCloudPlatform"
       name  = "example"
     }
-    terraform_root = "terraform"
+
+    # Required for scheduler.
+    scheduler_region = "us-east1"
+
     build_viewers  = ["group:example-cicd-viewers@example.com"]
     build_editors  = ["group:example-cicd-editors@example.com"]
 
+    terraform_root = "terraform"
     envs = [
       {
         name        = "prod"

--- a/examples/tfengine/team.hcl
+++ b/examples/tfengine/team.hcl
@@ -73,10 +73,13 @@ template "cicd" {
       name  = "example"
     }
 
-    terraform_root = "terraform"
+    # Required for scheduler.
+    scheduler_region = "us-east1"
+
     build_viewers  = ["group:example-cicd-viewers@example.com"]
     build_editors  = ["group:example-cicd-editors@example.com"]
 
+    terraform_root = "terraform"
     envs = [
       {
         name        = "prod"

--- a/templates/tfengine/components/cicd/main.tf
+++ b/templates/tfengine/components/cicd/main.tf
@@ -212,9 +212,9 @@ resource "google_project_iam_member" "cloudbuild_sa_project_iam" {
   ]
 }
 
-{{if $hasScheduledJobs -}}
 # Cloud Scheduler resources.
 # Cloud Scheduler requires an App Engine app created in the project.
+# App Engine app cannot be destroyed once created, therefore always create it.
 resource "google_app_engine_application" "cloudbuild_scheduler_app" {
   project     = var.project_id
   location_id = "{{.scheduler_region}}"
@@ -223,6 +223,7 @@ resource "google_app_engine_application" "cloudbuild_scheduler_app" {
   ]
 }
 
+{{if $hasScheduledJobs -}}
 # Service Account and its IAM permissions used for Cloud Scheduler to schedule Cloud Build triggers.
 resource "google_service_account" "cloudbuild_scheduler_sa" {
   project      = var.project_id

--- a/templates/tfengine/recipes/cicd.hcl
+++ b/templates/tfengine/recipes/cicd.hcl
@@ -18,6 +18,7 @@ schema = {
   required = [
     "envs",
     "terraform_root",
+    "scheduler_region",
   ]
   properties = {
     project_id = {


### PR DESCRIPTION
The reason is because the app cannot be destroyed after creation. So if
someone first enable scheduler but then disable it. Terraform will throw
errors to destroy it.