### PR TITLE
support groups in devops, add documentation and improve format

### DIFF
--- a/docs/tfengine/README.md
+++ b/docs/tfengine/README.md
@@ -233,7 +233,7 @@ directly use the `terraform` binary to deploy the infrastructure.
 
     ```hcl
     template "devops" {
-      recipe_path = "git://github.com/GoogleCloudPlatform/healthcare-data-protection-suite//templates/tfengine/recipes/devops.hcl?ref=templates-v0.1.0"
+      recipe_path = "git://github.com/GoogleCloudPlatform/healthcare-data-protection-suite//templates/tfengine/recipes/devops.hcl?ref=templates-v0.4.0"
       output_path = "./devops"
       data = {
         ...
@@ -248,9 +248,9 @@ directly use the `terraform` binary to deploy the infrastructure.
     OUTPUT_PATH=/tmp/engine
     ```
 
-   **NOTE**: If you plan to set up CICD, the `terraform_root` variable in the
-   CICD template should correspond to the parent directory in OUTPUT_PATH that
-   would be checked into source control.
+    **NOTE**: If you plan to set up CICD, the `terraform_root` variable in the
+    CICD template should correspond to the parent directory in OUTPUT_PATH that
+    would be checked into source control.
 
 1. Run the engine to generate your Terraform configs:
 
@@ -278,7 +278,6 @@ directly use the `terraform` binary to deploy the infrastructure.
         ```shell
         cd $OUTPUT_PATH/devops
         terraform init
-        terraform plan
         terraform apply
         ```
 
@@ -298,6 +297,49 @@ directly use the `terraform` binary to deploy the infrastructure.
         terraform init -force-copy
         ```
 
+1. (Optional) Create Cloud Identity Groups for coming IAM role assignments.
+
+    It is recommended to
+    [delegate responsibility](https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#groups-and-service-accounts)
+    through groups and service accounts so that individuals only obtain
+    permissions through groups rather than direct IAM roles.
+
+    1. Add a separate template called `groups` using the `project.hcl` recipe,
+        and define your groups and memberships in the `resources` block. Set the
+        `project_id` to the `devops` project ID and `exists` to `true`.
+
+        ```hcl
+        template "groups" {
+          recipe_path = "git://github.com/GoogleCloudPlatform/healthcare-data-protection-suite//templates/tfengine/recipes/project.hcl"
+          output_path = "./groups"
+          data = {
+            project = {
+              project_id = "example-devops"
+              exists     = true
+            }
+            resources = {
+              groups = [
+                {
+                  id = "example-group@example.com"
+                  customer_id = "c12345678"
+                  owners = ["user1@example.com"]
+                  members = ["user2@example.com"]
+                },
+              ]
+            }
+          }
+        }
+        ```
+
+    1. Create groups and initial memberships. You must be at least Google
+        Workspace Group Admin to be able to do so.
+
+        ```shell
+        cd $OUTPUT_PATH/groups
+        terraform init
+        terraform apply
+        ```
+
 1. (Optional) To deploy Continuous Integration (CI) and Continuous Deployment
     (CD) resources, follow the instructions
     [here](../../templates/tfengine/components/cicd/README.md) or equivalently,
@@ -307,6 +349,18 @@ directly use the `terraform` binary to deploy the infrastructure.
     should be made as Pull Requests (PRs) and go though code reviews. After
     approval is granted and CI tests pass, merge the PR. The CD job
     automatically deploys the change to your Google Cloud infra.
+
+    If you would like to enable CICD to manage groups for you:
+
+    1. Include `groups` in the `managed_dirs` of `cicd` template.
+    1. Follow manual steps
+        [here](https://cloud.google.com/identity/docs/how-to/setup#assigning_an_admin_role_to_the_service_account)
+        to assign the CICD service account Group Admin role. You must be a
+        Google Workspace Super Admin to be able to do so.
+
+    Note that the `groups` template must be deployed manually first if you also
+    use it to create groups to be used in the `cicd` template. These groups
+    should exist before `cicd` template can be deployed.
 
 1. Deploy org infrastructure and other resources by sending a PR for local
     changes to the config repo.

--- a/docs/tfengine/schemas/devops.md
+++ b/docs/tfengine/schemas/devops.md
@@ -6,9 +6,60 @@
 
 ### admins_group
 
-Group who will be given org admin access.
+Group which will be given admin access to the folder or organization.
+It will be created if 'exists' is false.
+
+Type: object
+
+### admins_group.customer_id
+
+Customer ID of the organization to create the group in.
+See <https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains#retrieving_customer_id>
+for how to obtain it.
 
 Type: string
+
+### admins_group.description
+
+Description of the group.
+
+Type: string
+
+### admins_group.display_name
+
+Display name of the group.
+
+Type: string
+
+### admins_group.exists
+
+Whether or not the group exists already. Default to 'false'.
+
+Type: boolean
+
+### admins_group.id
+
+Email address of the group.
+
+Type: string
+
+### admins_group.managers
+
+Managers of the group.
+
+Type: array(string)
+
+### admins_group.members
+
+Members of the group.
+
+Type: array(string)
+
+### admins_group.owners
+
+Owners of the group.
+
+Type: array(string)
 
 ### billing_account
 
@@ -61,12 +112,63 @@ NOTE: If a CICD is deployed within this project, then the APIs of
 all resources managed by the CICD must be listed here
 (even if the resources themselves are in different projects).
 
-### project.owners
+### project.owners_group
 
-List of members to transfer ownership of the project to.
-NOTE: By default the creating user will be the owner of the project.
-Thus, there should be a group in this list and you must be part of that group,
-so a group owns the project going forward.
+Group which will be given owner access to the project.
+It will be created if 'exists' is false.
+NOTE: By default, the creating user will be the owner of the project.
+However, this group will own the project going forward. Make sure to include
+yourselve in the group,
+
+Type: object
+
+### project.owners_group.customer_id
+
+Customer ID of the organization to create the group in.
+See <https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains#retrieving_customer_id>
+for how to obtain it.
+
+Type: string
+
+### project.owners_group.description
+
+Description of the group.
+
+Type: string
+
+### project.owners_group.display_name
+
+Display name of the group.
+
+Type: string
+
+### project.owners_group.exists
+
+Whether or not the group exists already. Default to 'false'.
+
+Type: boolean
+
+### project.owners_group.id
+
+Email address of the group.
+
+Type: string
+
+### project.owners_group.managers
+
+Managers of the group.
+
+Type: array(string)
+
+### project.owners_group.members
+
+Members of the group.
+
+Type: array(string)
+
+### project.owners_group.owners
+
+Owners of the group.
 
 Type: array(string)
 

--- a/docs/tfengine/schemas/resources.md
+++ b/docs/tfengine/schemas/resources.md
@@ -715,7 +715,7 @@ Type: string
 
 [Module](https://github.com/terraform-google-modules/terraform-google-group)
 
-Type: array()
+Type: array(object)
 
 ### groups.customer_id
 

--- a/examples/tfengine/devops.hcl
+++ b/examples/tfengine/devops.hcl
@@ -32,6 +32,7 @@ template "devops" {
 
     admins_group = {
       id = "example-org-admins@example.com"
+      # 'exists' can only be set to 'true' until Terraform 0.13 is supported.
       exists = true
     }
 
@@ -39,6 +40,7 @@ template "devops" {
       project_id = "example-devops"
       owners_group = {
         id = "example-devops-owners@example.com"
+        # 'exists' can only be set to 'true' until Terraform 0.13 is supported.
         exists = true
       }
     }

--- a/examples/tfengine/devops.hcl
+++ b/examples/tfengine/devops.hcl
@@ -30,12 +30,41 @@ template "devops" {
     # Run `terraform init` in the devops module to backup its state to GCS.
     # enable_gcs_backend = true
 
-    admins_group = "example-org-admins@example.com"
+    admins_group = {
+      id = "example-org-admins@example.com"
+      exists = true
+    }
 
     project = {
       project_id = "example-devops"
-      owners = [
-        "group:example-devops-owners@example.com",
+      owners_group = {
+        id = "example-devops-owners@example.com"
+        exists = true
+      }
+    }
+  }
+}
+
+# Must first be deployed manually before 'cicd' is deployed because some groups created
+# here are used in 'cicd' template.
+template "groups" {
+  recipe_path = "{{$recipes}}/project.hcl"
+  output_path = "./groups"
+  data = {
+    project = {
+      project_id = "example-devops"
+      exists     = true
+    }
+    resources = {
+      groups = [
+        {
+          id = "example-cicd-viewers@example.com"
+          customer_id = "c12345678"
+        },
+        {
+          id = "example-cicd-editors@example.com"
+          customer_id = "c12345678"
+        },
       ]
     }
   }

--- a/examples/tfengine/folder_foundation.hcl
+++ b/examples/tfengine/folder_foundation.hcl
@@ -35,12 +35,51 @@ template "devops" {
     # Run `terraform init` in the devops module to backup its state to GCS.
     # enable_gcs_backend = true
 
-    admins_group = "example-folder-admins@example.com"
+    admins_group = {
+      id = "example-folder-admins@example.com"
+      exists = true
+    }
 
     project = {
       project_id = "example-devops"
-      owners = [
-        "group:example-devops-owners@example.com",
+      owners_group = {
+        id = "example-devops-owners@example.com"
+        exists = true
+      }
+    }
+  }
+}
+
+# Must first be deployed manually before 'cicd' is deployed because some groups created
+# here are used in 'cicd' template.
+template "groups" {
+  recipe_path = "{{$recipes}}/project.hcl"
+  output_path = "./groups"
+  data = {
+    project = {
+      project_id = "example-devops"
+      exists     = true
+    }
+    resources = {
+      groups = [
+        {
+          id = "example-auditors@example.com"
+          customer_id = "c12345678"
+          owners = [
+            "user1@example.com"
+          ]
+          members = [
+            "user2@example.com"
+          ]
+        },
+        {
+          id = "example-cicd-viewers@example.com"
+          customer_id = "c12345678"
+        },
+        {
+          id = "example-cicd-editors@example.com"
+          customer_id = "c12345678"
+        },
       ]
     }
   }
@@ -86,31 +125,6 @@ template "cicd" {
         ]
       }
     ]
-  }
-}
-
-template "groups" {
-  recipe_path = "{{$recipes}}/project.hcl"
-  output_path = "./groups"
-  data = {
-    project = {
-      project_id = "example-devops"
-      exists     = true
-    }
-    resources = {
-      groups = [
-        {
-          id = "example-auditors@example.com"
-          customer_id = "c12345678"
-          owners = [
-            "user1@example.com"
-          ]
-          members = [
-            "user2@example.com"
-          ]
-        },
-      ]
-    }
   }
 }
 

--- a/examples/tfengine/folder_foundation.hcl
+++ b/examples/tfengine/folder_foundation.hcl
@@ -37,6 +37,7 @@ template "devops" {
 
     admins_group = {
       id = "example-folder-admins@example.com"
+      # 'exists' can only be set to 'true' until Terraform 0.13 is supported.
       exists = true
     }
 
@@ -44,6 +45,7 @@ template "devops" {
       project_id = "example-devops"
       owners_group = {
         id = "example-devops-owners@example.com"
+        # 'exists' can only be set to 'true' until Terraform 0.13 is supported.
         exists = true
       }
     }

--- a/examples/tfengine/generated/devops/cicd/main.tf
+++ b/examples/tfengine/generated/devops/cicd/main.tf
@@ -86,6 +86,7 @@ resource "google_project_service" "services" {
   service            = each.value
   disable_on_destroy = false
 }
+
 # IAM permissions to allow contributors to view the cloud build jobs.
 resource "google_project_iam_member" "cloudbuild_builds_viewers" {
   for_each = toset([
@@ -98,6 +99,7 @@ resource "google_project_iam_member" "cloudbuild_builds_viewers" {
     google_project_service.services,
   ]
 }
+
 # IAM permissions to allow approvers to edit/create the cloud build jobs.
 resource "google_project_iam_member" "cloudbuild_builds_editors" {
   for_each = toset([
@@ -125,8 +127,6 @@ resource "google_project_iam_member" "cloudbuild_logs_viewers" {
     google_project_service.services,
   ]
 }
-
-
 
 # Grant Cloud Build Service Account access to the devops project.
 resource "google_project_iam_member" "cloudbuild_sa_project_iam" {
@@ -170,6 +170,7 @@ resource "google_project_iam_member" "cloudbuild_scheduler_sa_project_iam" {
 }
 
 # Cloud Build - Cloud Build Service Account IAM permissions
+
 # IAM permissions to allow Cloud Build Service Account use the billing account.
 resource "google_billing_account_iam_member" "binding" {
   billing_account_id = var.billing_account

--- a/examples/tfengine/generated/devops/cicd/triggers.tf
+++ b/examples/tfengine/generated/devops/cicd/triggers.tf
@@ -73,6 +73,7 @@ resource "google_cloudbuild_trigger" "plan_prod" {
     google_project_service.services,
   ]
 }
+
 # Create another trigger as Pull Request Cloud Build triggers cannot be used by Cloud Scheduler.
 resource "google_cloudbuild_trigger" "plan_scheduled_prod" {
   # Always disabled on push to branch.

--- a/examples/tfengine/generated/devops/devops/main.tf
+++ b/examples/tfengine/generated/devops/devops/main.tf
@@ -18,7 +18,8 @@
 # - Deletion lien,
 # - Project level IAM permissions for the project owners,
 # - A Cloud Storage bucket to store Terraform states for all deployments,
-# - Org level IAM permissions for org admins.
+# - Admin permission at organization level,
+# - Cloud Identity groups and memberships, if requested.
 
 // TODO: replace with https://github.com/terraform-google-modules/terraform-google-bootstrap
 terraform {
@@ -62,7 +63,7 @@ resource "google_project_iam_binding" "devops_owners" {
   members = ["group:example-devops-owners@example.com"]
 }
 
-# Org level IAM permissions for org admins.
+# Admin permission at organization level.
 resource "google_organization_iam_member" "admin" {
   org_id = "12345678"
   role   = "roles/resourcemanager.organizationAdmin"

--- a/examples/tfengine/generated/devops/groups/main.tf
+++ b/examples/tfengine/generated/devops/groups/main.tf
@@ -19,19 +19,29 @@ terraform {
     google-beta = "~> 3.0"
   }
   backend "gcs" {
-    bucket = "{{.state_bucket}}"
-    prefix = "{{get . "state_path_prefix" .output_path}}"
+    bucket = "example-terraform-state"
+    prefix = "groups"
   }
 }
 
-{{if has . "groups" -}}
 # Required when using end-user ADCs (Application Default Credentials) to manage Cloud Identity groups and memberships.
 provider "google-beta" {
   user_project_override = true
-  billing_project       = {{- if get .project "exists" false}} "{{.project.project_id}}" {{- else}} module.project.project_id {{end}}
+  billing_project       = "example-devops"
 }
-{{end -}}
 
-{{if has . "raw_config" -}}
-{{.raw_config}}
-{{end -}}
+module "example_cicd_viewers_example_com" {
+  source  = "terraform-google-modules/group/google"
+  version = "~> 0.1"
+
+  id          = "example-cicd-viewers@example.com"
+  customer_id = "c12345678"
+}
+
+module "example_cicd_editors_example_com" {
+  source  = "terraform-google-modules/group/google"
+  version = "~> 0.1"
+
+  id          = "example-cicd-editors@example.com"
+  customer_id = "c12345678"
+}

--- a/examples/tfengine/generated/folder_foundation/cicd/main.tf
+++ b/examples/tfengine/generated/folder_foundation/cicd/main.tf
@@ -84,6 +84,7 @@ resource "google_project_service" "services" {
   service            = each.value
   disable_on_destroy = false
 }
+
 # IAM permissions to allow contributors to view the cloud build jobs.
 resource "google_project_iam_member" "cloudbuild_builds_viewers" {
   for_each = toset([
@@ -96,6 +97,7 @@ resource "google_project_iam_member" "cloudbuild_builds_viewers" {
     google_project_service.services,
   ]
 }
+
 # IAM permissions to allow approvers to edit/create the cloud build jobs.
 resource "google_project_iam_member" "cloudbuild_builds_editors" {
   for_each = toset([
@@ -123,8 +125,6 @@ resource "google_project_iam_member" "cloudbuild_logs_viewers" {
     google_project_service.services,
   ]
 }
-
-
 
 # Grant Cloud Build Service Account access to the devops project.
 resource "google_project_iam_member" "cloudbuild_sa_project_iam" {
@@ -168,6 +168,7 @@ resource "google_project_iam_member" "cloudbuild_scheduler_sa_project_iam" {
 }
 
 # Cloud Build - Cloud Build Service Account IAM permissions
+
 # IAM permissions to allow Cloud Build Service Account use the billing account.
 resource "google_billing_account_iam_member" "binding" {
   billing_account_id = var.billing_account

--- a/examples/tfengine/generated/folder_foundation/cicd/triggers.tf
+++ b/examples/tfengine/generated/folder_foundation/cicd/triggers.tf
@@ -73,6 +73,7 @@ resource "google_cloudbuild_trigger" "plan_prod" {
     google_project_service.services,
   ]
 }
+
 # Create another trigger as Pull Request Cloud Build triggers cannot be used by Cloud Scheduler.
 resource "google_cloudbuild_trigger" "plan_scheduled_prod" {
   # Always disabled on push to branch.

--- a/examples/tfengine/generated/folder_foundation/devops/main.tf
+++ b/examples/tfengine/generated/folder_foundation/devops/main.tf
@@ -18,7 +18,8 @@
 # - Deletion lien,
 # - Project level IAM permissions for the project owners,
 # - A Cloud Storage bucket to store Terraform states for all deployments,
-# - Org level IAM permissions for org admins.
+# - Admin permission at folder level,
+# - Cloud Identity groups and memberships, if requested.
 
 // TODO: replace with https://github.com/terraform-google-modules/terraform-google-bootstrap
 terraform {
@@ -63,7 +64,7 @@ resource "google_project_iam_binding" "devops_owners" {
   members = ["group:example-devops-owners@example.com"]
 }
 
-# Org level IAM permissions for org admins.
+# Admin permission at folder level.
 resource "google_folder_iam_member" "admin" {
   folder = "folders/12345678"
   role   = "roles/resourcemanager.folderAdmin"

--- a/examples/tfengine/generated/folder_foundation/groups/main.tf
+++ b/examples/tfengine/generated/folder_foundation/groups/main.tf
@@ -24,7 +24,7 @@ terraform {
   }
 }
 
-# Required for Cloud Identity API to create and manage groups.
+# Required when using end-user ADCs (Application Default Credentials) to manage Cloud Identity groups and memberships.
 provider "google-beta" {
   user_project_override = true
   billing_project       = "example-devops"
@@ -36,7 +36,22 @@ module "example_auditors_example_com" {
 
   id          = "example-auditors@example.com"
   customer_id = "c12345678"
+  owners      = ["user1@example.com"]
+  members     = ["user2@example.com"]
+}
 
-  owners  = ["user1@example.com"]
-  members = ["user2@example.com"]
+module "example_cicd_viewers_example_com" {
+  source  = "terraform-google-modules/group/google"
+  version = "~> 0.1"
+
+  id          = "example-cicd-viewers@example.com"
+  customer_id = "c12345678"
+}
+
+module "example_cicd_editors_example_com" {
+  source  = "terraform-google-modules/group/google"
+  version = "~> 0.1"
+
+  id          = "example-cicd-editors@example.com"
+  customer_id = "c12345678"
 }

--- a/examples/tfengine/generated/multi_envs/cicd/main.tf
+++ b/examples/tfengine/generated/multi_envs/cicd/main.tf
@@ -83,6 +83,7 @@ resource "google_project_service" "services" {
   service            = each.value
   disable_on_destroy = false
 }
+
 # IAM permissions to allow contributors to view the cloud build jobs.
 resource "google_project_iam_member" "cloudbuild_builds_viewers" {
   for_each = toset([
@@ -95,6 +96,7 @@ resource "google_project_iam_member" "cloudbuild_builds_viewers" {
     google_project_service.services,
   ]
 }
+
 # IAM permissions to allow approvers to edit/create the cloud build jobs.
 resource "google_project_iam_member" "cloudbuild_builds_editors" {
   for_each = toset([
@@ -134,7 +136,7 @@ resource "google_sourcerepo_repository" "configs" {
 
 resource "google_sourcerepo_repository_iam_member" "readers" {
   for_each = toset([
-    "group:readers@example.com",
+    "group:example-source-readers@example.com",
   ])
   project    = var.project_id
   repository = google_sourcerepo_repository.configs.name
@@ -144,7 +146,7 @@ resource "google_sourcerepo_repository_iam_member" "readers" {
 
 resource "google_sourcerepo_repository_iam_member" "writers" {
   for_each = toset([
-    "user:foo@example.com",
+    "group:example-source-writers@example.com",
   ])
   project    = var.project_id
   repository = google_sourcerepo_repository.configs.name
@@ -174,9 +176,8 @@ resource "google_app_engine_application" "cloudbuild_scheduler_app" {
   ]
 }
 
-
-
 # Cloud Build - Cloud Build Service Account IAM permissions
+
 # IAM permissions to allow Cloud Build Service Account use the billing account.
 resource "google_billing_account_iam_member" "binding" {
   billing_account_id = var.billing_account

--- a/examples/tfengine/generated/multi_envs/devops/main.tf
+++ b/examples/tfengine/generated/multi_envs/devops/main.tf
@@ -18,7 +18,8 @@
 # - Deletion lien,
 # - Project level IAM permissions for the project owners,
 # - A Cloud Storage bucket to store Terraform states for all deployments,
-# - Org level IAM permissions for org admins.
+# - Admin permission at folder level,
+# - Cloud Identity groups and memberships, if requested.
 
 // TODO: replace with https://github.com/terraform-google-modules/terraform-google-bootstrap
 terraform {
@@ -27,6 +28,12 @@ terraform {
     google      = "~> 3.0"
     google-beta = "~> 3.0"
   }
+}
+
+# Required when using end-user ADCs (Application Default Credentials) to manage Cloud Identity groups and memberships.
+provider "google-beta" {
+  user_project_override = true
+  billing_project       = "example-devops"
 }
 
 # Create the project, enable APIs, and create the deletion lien, if specified.
@@ -56,16 +63,41 @@ module "state_bucket" {
   location   = "us-central1"
 }
 
+# Devops project owners group.
+module "owners_group" {
+  source  = "terraform-google-modules/group/google"
+  version = "~> 0.1"
+
+  id          = "example-devops-owners@example.com"
+  customer_id = "c12345678"
+  owners      = ["user1@example.com"]
+  depends_on = [
+    module.project
+  ]
+}
+
 # Project level IAM permissions for devops project owners.
 resource "google_project_iam_binding" "devops_owners" {
   project = module.project.project_id
   role    = "roles/owner"
-  members = ["group:example-devops-owners@example.com"]
+  members = ["group:${module.owners_group.id}"]
 }
 
-# Org level IAM permissions for org admins.
+# Admins group for at folder level.
+module "admins_group" {
+  source  = "terraform-google-modules/group/google"
+  version = "~> 0.1"
+
+  id          = "example-folder-admins@example.com"
+  customer_id = "c12345678"
+  depends_on = [
+    module.project
+  ]
+}
+
+# Admin permission at folder level.
 resource "google_folder_iam_member" "admin" {
   folder = "folders/12345678"
   role   = "roles/resourcemanager.folderAdmin"
-  member = "group:example-folder-admins@example.com"
+  member = "group:${module.admins_group.id}"
 }

--- a/examples/tfengine/generated/multi_envs/groups/main.tf
+++ b/examples/tfengine/generated/multi_envs/groups/main.tf
@@ -24,7 +24,7 @@ terraform {
   }
 }
 
-# Required for Cloud Identity API to create and manage groups.
+# Required when using end-user ADCs (Application Default Credentials) to manage Cloud Identity groups and memberships.
 provider "google-beta" {
   user_project_override = true
   billing_project       = "example-devops"
@@ -36,7 +36,38 @@ module "example_auditors_example_com" {
 
   id          = "example-auditors@example.com"
   customer_id = "c12345678"
+  owners      = ["user1@example.com"]
+  members     = ["user2@example.com"]
+}
 
-  owners  = ["user1@example.com"]
-  members = ["user2@example.com"]
+module "example_cicd_viewers_example_com" {
+  source  = "terraform-google-modules/group/google"
+  version = "~> 0.1"
+
+  id          = "example-cicd-viewers@example.com"
+  customer_id = "c12345678"
+}
+
+module "example_cicd_editors_example_com" {
+  source  = "terraform-google-modules/group/google"
+  version = "~> 0.1"
+
+  id          = "example-cicd-editors@example.com"
+  customer_id = "c12345678"
+}
+
+module "example_source_readers_example_com" {
+  source  = "terraform-google-modules/group/google"
+  version = "~> 0.1"
+
+  id          = "example-source-readers@example.com"
+  customer_id = "c12345678"
+}
+
+module "example_source_writers_example_com" {
+  source  = "terraform-google-modules/group/google"
+  version = "~> 0.1"
+
+  id          = "example-source-writers@example.com"
+  customer_id = "c12345678"
 }

--- a/examples/tfengine/generated/org_foundation/cicd/main.tf
+++ b/examples/tfengine/generated/org_foundation/cicd/main.tf
@@ -84,6 +84,7 @@ resource "google_project_service" "services" {
   service            = each.value
   disable_on_destroy = false
 }
+
 # IAM permissions to allow contributors to view the cloud build jobs.
 resource "google_project_iam_member" "cloudbuild_builds_viewers" {
   for_each = toset([
@@ -96,6 +97,7 @@ resource "google_project_iam_member" "cloudbuild_builds_viewers" {
     google_project_service.services,
   ]
 }
+
 # IAM permissions to allow approvers to edit/create the cloud build jobs.
 resource "google_project_iam_member" "cloudbuild_builds_editors" {
   for_each = toset([
@@ -124,8 +126,6 @@ resource "google_project_iam_member" "cloudbuild_logs_viewers" {
   ]
 }
 
-
-
 # Grant Cloud Build Service Account access to the devops project.
 resource "google_project_iam_member" "cloudbuild_sa_project_iam" {
   for_each = toset(local.cloudbuild_devops_roles)
@@ -148,9 +148,8 @@ resource "google_app_engine_application" "cloudbuild_scheduler_app" {
   ]
 }
 
-
-
 # Cloud Build - Cloud Build Service Account IAM permissions
+
 # IAM permissions to allow Cloud Build Service Account use the billing account.
 resource "google_billing_account_iam_member" "binding" {
   billing_account_id = var.billing_account

--- a/examples/tfengine/generated/org_foundation/devops/main.tf
+++ b/examples/tfengine/generated/org_foundation/devops/main.tf
@@ -18,7 +18,8 @@
 # - Deletion lien,
 # - Project level IAM permissions for the project owners,
 # - A Cloud Storage bucket to store Terraform states for all deployments,
-# - Org level IAM permissions for org admins.
+# - Admin permission at organization level,
+# - Cloud Identity groups and memberships, if requested.
 
 // TODO: replace with https://github.com/terraform-google-modules/terraform-google-bootstrap
 terraform {
@@ -62,7 +63,7 @@ resource "google_project_iam_binding" "devops_owners" {
   members = ["group:example-devops-owners@example.com"]
 }
 
-# Org level IAM permissions for org admins.
+# Admin permission at organization level.
 resource "google_organization_iam_member" "admin" {
   org_id = "12345678"
   role   = "roles/resourcemanager.organizationAdmin"

--- a/examples/tfengine/generated/org_foundation/groups/main.tf
+++ b/examples/tfengine/generated/org_foundation/groups/main.tf
@@ -24,7 +24,7 @@ terraform {
   }
 }
 
-# Required for Cloud Identity API to create and manage groups.
+# Required when using end-user ADCs (Application Default Credentials) to manage Cloud Identity groups and memberships.
 provider "google-beta" {
   user_project_override = true
   billing_project       = "example-devops"
@@ -36,7 +36,22 @@ module "example_auditors_example_com" {
 
   id          = "example-auditors@example.com"
   customer_id = "c12345678"
+  owners      = ["user1@example.com"]
+  members     = ["user2@example.com"]
+}
 
-  owners  = ["user1@example.com"]
-  members = ["user2@example.com"]
+module "example_cicd_viewers_example_com" {
+  source  = "terraform-google-modules/group/google"
+  version = "~> 0.1"
+
+  id          = "example-cicd-viewers@example.com"
+  customer_id = "c12345678"
+}
+
+module "example_cicd_editors_example_com" {
+  source  = "terraform-google-modules/group/google"
+  version = "~> 0.1"
+
+  id          = "example-cicd-editors@example.com"
+  customer_id = "c12345678"
 }

--- a/examples/tfengine/generated/team/cicd/main.tf
+++ b/examples/tfengine/generated/team/cicd/main.tf
@@ -82,6 +82,7 @@ resource "google_project_service" "services" {
   service            = each.value
   disable_on_destroy = false
 }
+
 # IAM permissions to allow contributors to view the cloud build jobs.
 resource "google_project_iam_member" "cloudbuild_builds_viewers" {
   for_each = toset([
@@ -94,6 +95,7 @@ resource "google_project_iam_member" "cloudbuild_builds_viewers" {
     google_project_service.services,
   ]
 }
+
 # IAM permissions to allow approvers to edit/create the cloud build jobs.
 resource "google_project_iam_member" "cloudbuild_builds_editors" {
   for_each = toset([
@@ -122,8 +124,6 @@ resource "google_project_iam_member" "cloudbuild_logs_viewers" {
   ]
 }
 
-
-
 # Grant Cloud Build Service Account access to the devops project.
 resource "google_project_iam_member" "cloudbuild_sa_project_iam" {
   for_each = toset(local.cloudbuild_devops_roles)
@@ -146,9 +146,8 @@ resource "google_app_engine_application" "cloudbuild_scheduler_app" {
   ]
 }
 
-
-
 # Cloud Build - Cloud Build Service Account IAM permissions
+
 # IAM permissions to allow Cloud Build Service Account use the billing account.
 resource "google_billing_account_iam_member" "binding" {
   billing_account_id = var.billing_account

--- a/examples/tfengine/generated/team/devops/main.tf
+++ b/examples/tfengine/generated/team/devops/main.tf
@@ -18,7 +18,8 @@
 # - Deletion lien,
 # - Project level IAM permissions for the project owners,
 # - A Cloud Storage bucket to store Terraform states for all deployments,
-# - Org level IAM permissions for org admins.
+# - Admin permission at folder level,
+# - Cloud Identity groups and memberships, if requested.
 
 // TODO: replace with https://github.com/terraform-google-modules/terraform-google-bootstrap
 terraform {
@@ -69,7 +70,7 @@ resource "google_project_iam_binding" "devops_owners" {
   members = ["group:example-devops-owners@example.com"]
 }
 
-# Org level IAM permissions for org admins.
+# Admin permission at folder level.
 resource "google_folder_iam_member" "admin" {
   folder = "folders/12345678"
   role   = "roles/resourcemanager.folderAdmin"

--- a/examples/tfengine/generated/team/groups/main.tf
+++ b/examples/tfengine/generated/team/groups/main.tf
@@ -24,10 +24,26 @@ terraform {
   }
 }
 
-# Required for Cloud Identity API to create and manage groups.
+# Required when using end-user ADCs (Application Default Credentials) to manage Cloud Identity groups and memberships.
 provider "google-beta" {
   user_project_override = true
   billing_project       = "example-devops"
+}
+
+module "example_cicd_viewers_example_com" {
+  source  = "terraform-google-modules/group/google"
+  version = "~> 0.1"
+
+  id          = "example-cicd-viewers@example.com"
+  customer_id = "c12345678"
+}
+
+module "example_cicd_editors_example_com" {
+  source  = "terraform-google-modules/group/google"
+  version = "~> 0.1"
+
+  id          = "example-cicd-editors@example.com"
+  customer_id = "c12345678"
 }
 
 module "example_apps_viewers_example_com" {
@@ -36,8 +52,7 @@ module "example_apps_viewers_example_com" {
 
   id          = "example-apps-viewers@example.com"
   customer_id = "c12345678"
-
-  owners = ["user1@example.com"]
+  owners      = ["user1@example.com"]
 }
 
 module "example_data_viewers_example_com" {
@@ -46,8 +61,7 @@ module "example_data_viewers_example_com" {
 
   id          = "example-data-viewers@example.com"
   customer_id = "c12345678"
-
-  owners = ["user1@example.com"]
+  owners      = ["user1@example.com"]
 }
 
 module "example_healthcare_dataset_viewers_example_com" {
@@ -56,8 +70,7 @@ module "example_healthcare_dataset_viewers_example_com" {
 
   id          = "example-healthcare-dataset-viewers@example.com"
   customer_id = "c12345678"
-
-  owners = ["user1@example.com"]
+  owners      = ["user1@example.com"]
 }
 
 module "example_fhir_viewers_example_com" {
@@ -66,8 +79,7 @@ module "example_fhir_viewers_example_com" {
 
   id          = "example-fhir-viewers@example.com"
   customer_id = "c12345678"
-
-  owners = ["user1@example.com"]
+  owners      = ["user1@example.com"]
 }
 
 module "bastion_accessors_example_com" {
@@ -76,6 +88,5 @@ module "bastion_accessors_example_com" {
 
   id          = "bastion-accessors@example.com"
   customer_id = "c12345678"
-
-  owners = ["user1@example.com"]
+  owners      = ["user1@example.com"]
 }

--- a/examples/tfengine/multi_envs.hcl
+++ b/examples/tfengine/multi_envs.hcl
@@ -37,17 +37,16 @@ template "devops" {
 
     admins_group = {
       id = "example-folder-admins@example.com"
-      customer_id = "c12345678"
+      # 'exists' can only be set to 'true' until Terraform 0.13 is supported.
+      exists = true
     }
 
     project = {
       project_id = "example-devops"
       owners_group = {
         id = "example-devops-owners@example.com"
-        customer_id = "c12345678"
-        owners = [
-          "user1@example.com"
-        ]
+        # 'exists' can only be set to 'true' until Terraform 0.13 is supported.
+        exists = true
       }
     }
   }

--- a/examples/tfengine/multi_envs.hcl
+++ b/examples/tfengine/multi_envs.hcl
@@ -35,12 +35,62 @@ template "devops" {
     # Run `terraform init` in the devops module to backup its state to GCS.
     # enable_gcs_backend = true
 
-    admins_group = "example-folder-admins@example.com"
+    admins_group = {
+      id = "example-folder-admins@example.com"
+      customer_id = "c12345678"
+    }
 
     project = {
       project_id = "example-devops"
-      owners = [
-        "group:example-devops-owners@example.com",
+      owners_group = {
+        id = "example-devops-owners@example.com"
+        customer_id = "c12345678"
+        owners = [
+          "user1@example.com"
+        ]
+      }
+    }
+  }
+}
+
+# Must first be deployed manually before 'cicd' is deployed because some groups created
+# here are used in 'cicd' template.
+template "groups" {
+  recipe_path = "{{$recipes}}/project.hcl"
+  output_path = "./groups"
+  data = {
+    project = {
+      project_id = "example-devops"
+      exists     = true
+    }
+    resources = {
+      groups = [
+        {
+          id = "example-auditors@example.com"
+          customer_id = "c12345678"
+          owners = [
+            "user1@example.com"
+          ]
+          members = [
+            "user2@example.com"
+          ]
+        },
+        {
+          id = "example-cicd-viewers@example.com"
+          customer_id = "c12345678"
+        },
+        {
+          id = "example-cicd-editors@example.com"
+          customer_id = "c12345678"
+        },
+        {
+          id = "example-source-readers@example.com"
+          customer_id = "c12345678"
+        },
+        {
+          id = "example-source-writers@example.com"
+          customer_id = "c12345678"
+        },
       ]
     }
   }
@@ -54,10 +104,10 @@ template "cicd" {
     cloud_source_repository = {
       name = "example"
       readers = [
-        "group:readers@example.com"
+        "group:example-source-readers@example.com"
       ]
       writers = [
-        "user:foo@example.com"
+        "group:example-source-writers@example.com"
       ]
     }
 
@@ -111,31 +161,6 @@ template "cicd" {
         ]
       }
     ]
-  }
-}
-
-template "groups" {
-  recipe_path = "{{$recipes}}/project.hcl"
-  output_path = "./groups"
-  data = {
-    project = {
-      project_id = "example-devops"
-      exists     = true
-    }
-    resources = {
-      groups = [
-        {
-          id = "example-auditors@example.com"
-          customer_id = "c12345678"
-          owners = [
-            "user1@example.com"
-          ]
-          members = [
-            "user2@example.com"
-          ]
-        },
-      ]
-    }
   }
 }
 

--- a/examples/tfengine/org_foundation.hcl
+++ b/examples/tfengine/org_foundation.hcl
@@ -37,6 +37,7 @@ template "devops" {
 
     admins_group = {
       id = "example-org-admins@example.com"
+      # 'exists' can only be set to 'true' until Terraform 0.13 is supported.
       exists = true
     }
 
@@ -44,6 +45,7 @@ template "devops" {
       project_id = "example-devops"
       owners_group = {
         id = "example-devops-owners@example.com"
+        # 'exists' can only be set to 'true' until Terraform 0.13 is supported.
         exists = true
       }
     }

--- a/examples/tfengine/org_foundation.hcl
+++ b/examples/tfengine/org_foundation.hcl
@@ -35,12 +35,51 @@ template "devops" {
     # Run `terraform init` in the devops module to backup its state to GCS.
     # enable_gcs_backend = true
 
-    admins_group = "example-org-admins@example.com"
+    admins_group = {
+      id = "example-org-admins@example.com"
+      exists = true
+    }
 
     project = {
       project_id = "example-devops"
-      owners = [
-        "group:example-devops-owners@example.com",
+      owners_group = {
+        id = "example-devops-owners@example.com"
+        exists = true
+      }
+    }
+  }
+}
+
+# Must first be deployed manually before 'cicd' is deployed because some groups created
+# here are used in 'cicd' template.
+template "groups" {
+  recipe_path = "{{$recipes}}/project.hcl"
+  output_path = "./groups"
+  data = {
+    project = {
+      project_id = "example-devops"
+      exists     = true
+    }
+    resources = {
+      groups = [
+        {
+          id = "example-auditors@example.com"
+          customer_id = "c12345678"
+          owners = [
+            "user1@example.com"
+          ]
+          members = [
+            "user2@example.com"
+          ]
+        },
+        {
+          id = "example-cicd-viewers@example.com"
+          customer_id = "c12345678"
+        },
+        {
+          id = "example-cicd-editors@example.com"
+          customer_id = "c12345678"
+        },
       ]
     }
   }
@@ -84,31 +123,6 @@ template "cicd" {
         ]
       }
     ]
-  }
-}
-
-template "groups" {
-  recipe_path = "{{$recipes}}/project.hcl"
-  output_path = "./groups"
-  data = {
-    project = {
-      project_id = "example-devops"
-      exists     = true
-    }
-    resources = {
-      groups = [
-        {
-          id = "example-auditors@example.com"
-          customer_id = "c12345678"
-          owners = [
-            "user1@example.com"
-          ]
-          members = [
-            "user2@example.com"
-          ]
-        },
-      ]
-    }
   }
 }
 

--- a/examples/tfengine/team.hcl
+++ b/examples/tfengine/team.hcl
@@ -44,13 +44,17 @@ template "devops" {
     # Run `terraform init` in the devops module to backup its state to GCS.
     # enable_gcs_backend = true
 
-    admins_group = "example-team-admins@example.com"
+    admins_group = {
+      id = "example-team-admins@example.com"
+      exists = true
+    }
 
     project = {
       project_id = "example-devops"
-      owners = [
-        "group:example-devops-owners@example.com",
-      ]
+      owners_group = {
+        id = "example-devops-owners@example.com"
+        exists = true
+      }
       apis = [
         "container.googleapis.com",
         "dns.googleapis.com",
@@ -58,6 +62,68 @@ template "devops" {
         "iap.googleapis.com",
         "pubsub.googleapis.com",
         "secretmanager.googleapis.com",
+      ]
+    }
+  }
+}
+
+# Must first be deployed manually before 'cicd' is deployed because some groups created
+# here are used in 'cicd' template.
+template "groups" {
+  recipe_path = "{{$recipes}}/project.hcl"
+  output_path = "./groups"
+  data = {
+    project = {
+      project_id = "example-devops"
+      exists     = true
+    }
+    resources = {
+      groups = [
+        # Groups used in the CICD.
+        {
+          id = "example-cicd-viewers@example.com"
+          customer_id = "c12345678"
+        },
+        {
+          id = "example-cicd-editors@example.com"
+          customer_id = "c12345678"
+        },
+        # Groups used in the applications.
+        {
+          id = "example-apps-viewers@example.com"
+          customer_id = "c12345678"
+          owners = [
+            "user1@example.com"
+          ]
+        },
+        {
+          id = "example-data-viewers@example.com"
+          customer_id = "c12345678"
+          owners = [
+            "user1@example.com"
+          ]
+        },
+        {
+          id = "example-healthcare-dataset-viewers@example.com"
+          customer_id = "c12345678"
+          owners = [
+            "user1@example.com"
+          ]
+        },
+        {
+          id = "example-fhir-viewers@example.com"
+          customer_id = "c12345678"
+          owners = [
+            "user1@example.com"
+          ]
+        },
+        {
+          id = "bastion-accessors@example.com"
+          customer_id = "c12345678"
+          owners = [
+            "user1@example.com"
+          ]
+        },
       ]
     }
   }
@@ -100,56 +166,6 @@ template "cicd" {
         ]
       }
     ]
-  }
-}
-
-template "groups" {
-  recipe_path = "{{$recipes}}/project.hcl"
-  output_path = "./groups"
-  data = {
-    project = {
-      project_id = "example-devops"
-      exists     = true
-    }
-    resources = {
-      groups = [
-        {
-          id = "example-apps-viewers@example.com"
-          customer_id = "c12345678"
-          owners = [
-            "user1@example.com"
-          ]
-        },
-        {
-          id = "example-data-viewers@example.com"
-          customer_id = "c12345678"
-          owners = [
-            "user1@example.com"
-          ]
-        },
-        {
-          id = "example-healthcare-dataset-viewers@example.com"
-          customer_id = "c12345678"
-          owners = [
-            "user1@example.com"
-          ]
-        },
-        {
-          id = "example-fhir-viewers@example.com"
-          customer_id = "c12345678"
-          owners = [
-            "user1@example.com"
-          ]
-        },
-        {
-          id = "bastion-accessors@example.com"
-          customer_id = "c12345678"
-          owners = [
-            "user1@example.com"
-          ]
-        },
-      ]
-    }
   }
 }
 

--- a/examples/tfengine/team.hcl
+++ b/examples/tfengine/team.hcl
@@ -46,6 +46,7 @@ template "devops" {
 
     admins_group = {
       id = "example-team-admins@example.com"
+      # 'exists' can only be set to 'true' until Terraform 0.13 is supported.
       exists = true
     }
 
@@ -53,6 +54,7 @@ template "devops" {
       project_id = "example-devops"
       owners_group = {
         id = "example-devops-owners@example.com"
+        # 'exists' can only be set to 'true' until Terraform 0.13 is supported.
         exists = true
       }
       apis = [

--- a/templates/tfengine/components/cicd/main.tf
+++ b/templates/tfengine/components/cicd/main.tf
@@ -106,6 +106,7 @@ resource "google_project_service" "services" {
 }
 
 {{- if has . "build_viewers"}}
+
 # IAM permissions to allow contributors to view the cloud build jobs.
 resource "google_project_iam_member" "cloudbuild_builds_viewers" {
   for_each = toset([
@@ -123,6 +124,7 @@ resource "google_project_iam_member" "cloudbuild_builds_viewers" {
 {{- end}}
 
 {{- if has . "build_editors"}}
+
 # IAM permissions to allow approvers to edit/create the cloud build jobs.
 resource "google_project_iam_member" "cloudbuild_builds_editors" {
   for_each = toset([
@@ -162,7 +164,8 @@ resource "google_project_iam_member" "cloudbuild_logs_viewers" {
   ]
 }
 
-{{if has . "cloud_source_repository" -}}
+{{- if has . "cloud_source_repository"}}
+
 # Create the Cloud Source Repository.
 resource "google_sourcerepo_repository" "configs" {
   project  = var.project_id
@@ -172,7 +175,8 @@ resource "google_sourcerepo_repository" "configs" {
   ]
 }
 
-{{if has .cloud_source_repository "readers" -}}
+{{- if has .cloud_source_repository "readers"}}
+
 resource "google_sourcerepo_repository_iam_member" "readers" {
   for_each = toset([
     {{- range .cloud_source_repository.readers}}
@@ -186,7 +190,8 @@ resource "google_sourcerepo_repository_iam_member" "readers" {
 }
 {{- end}}
 
-{{if has .cloud_source_repository "writers" -}}
+{{- if has .cloud_source_repository "writers"}}
+
 resource "google_sourcerepo_repository_iam_member" "writers" {
   for_each = toset([
     {{- range .cloud_source_repository.writers}}
@@ -223,7 +228,8 @@ resource "google_app_engine_application" "cloudbuild_scheduler_app" {
   ]
 }
 
-{{if $hasScheduledJobs -}}
+{{- if $hasScheduledJobs}}
+
 # Service Account and its IAM permissions used for Cloud Scheduler to schedule Cloud Build triggers.
 resource "google_service_account" "cloudbuild_scheduler_sa" {
   project      = var.project_id
@@ -246,6 +252,7 @@ resource "google_project_iam_member" "cloudbuild_scheduler_sa_project_iam" {
 
 # Cloud Build - Cloud Build Service Account IAM permissions
 {{- if $hasApplyJobs}}
+
 # IAM permissions to allow Cloud Build Service Account use the billing account.
 resource "google_billing_account_iam_member" "binding" {
   billing_account_id = var.billing_account

--- a/templates/tfengine/components/cicd/triggers.tf
+++ b/templates/tfengine/components/cicd/triggers.tf
@@ -30,7 +30,8 @@
 {{- $managed_dirs = trimSpace (printf "%s %s" $managed_dirs .)}}
 {{- end}}
 
-{{if has .triggers "validate" -}}
+{{- if has .triggers "validate"}}
+
 resource "google_cloudbuild_trigger" "validate_{{.name}}" {
   {{- if not (get .triggers.validate "run_on_push" true)}}
   disabled    = true
@@ -75,6 +76,7 @@ resource "google_cloudbuild_trigger" "validate_{{.name}}" {
 }
 
 {{- if has .triggers.validate "run_on_schedule"}}
+
 # Create another trigger as Pull Request Cloud Build triggers cannot be used by Cloud Scheduler.
 resource "google_cloudbuild_trigger" "validate_scheduled_{{.name}}" {
   # Always disabled on push to branch.
@@ -142,7 +144,8 @@ resource "google_cloud_scheduler_job" "validate_scheduler_{{.name}}" {
 {{- end}}
 {{- end}}
 
-{{if has .triggers "plan" -}}
+{{- if has .triggers "plan"}}
+
 resource "google_cloudbuild_trigger" "plan_{{.name}}" {
   {{- if not (get .triggers.plan "run_on_push" true)}}
   disabled    = true
@@ -187,6 +190,7 @@ resource "google_cloudbuild_trigger" "plan_{{.name}}" {
 }
 
 {{- if has .triggers.plan "run_on_schedule"}}
+
 # Create another trigger as Pull Request Cloud Build triggers cannot be used by Cloud Scheduler.
 resource "google_cloudbuild_trigger" "plan_scheduled_{{.name}}" {
   # Always disabled on push to branch.
@@ -254,7 +258,8 @@ resource "google_cloud_scheduler_job" "plan_scheduler_{{.name}}" {
 {{- end}}
 {{- end}}
 
-{{if has .triggers "apply" -}}
+{{- if has .triggers "apply"}}
+
 resource "google_cloudbuild_trigger" "apply_{{.name}}" {
   {{- if not (get .triggers.apply "run_on_push" true)}}
   disabled    = true
@@ -299,6 +304,7 @@ resource "google_cloudbuild_trigger" "apply_{{.name}}" {
 }
 
 {{- if has .triggers.apply "run_on_schedule"}}
+
 resource "google_cloud_scheduler_job" "apply_scheduler_{{.name}}" {
   project   = var.project_id
   name      = "apply-scheduler-{{.name}}"

--- a/templates/tfengine/components/resources/groups/main.tf
+++ b/templates/tfengine/components/resources/groups/main.tf
@@ -19,10 +19,8 @@ module "{{resourceName . "id"}}" {
 
   id = "{{.id}}"
   customer_id = "{{.customer_id}}"
-
   {{hclField . "description" -}}
   {{hclField . "display_name" -}}
-
   {{hclField . "owners" -}}
   {{hclField . "managers" -}}
   {{hclField . "members" -}}

--- a/templates/tfengine/recipes/devops.hcl
+++ b/templates/tfengine/recipes/devops.hcl
@@ -15,6 +15,10 @@
 schema = {
   title                = "Devops Recipe"
   additionalProperties = false
+  required = [
+    "admins_group",
+    "project",
+  ]
   properties = {
     parent_type = {
       description = <<EOF
@@ -40,21 +44,74 @@ schema = {
       description          = "Config for the project to host devops resources such as remote state and CICD."
       type                 = "object"
       additionalProperties = false
+      required = [
+        "project_id",
+        "owners_group",
+      ]
       properties = {
         project_id = {
           description = "ID of project."
           type        = "string"
         }
-        owners = {
+        owners_group = {
           description = <<EOF
-            List of members to transfer ownership of the project to.
-            NOTE: By default the creating user will be the owner of the project.
-            Thus, there should be a group in this list and you must be part of that group,
-            so a group owns the project going forward.
+            Group which will be given owner access to the project.
+            It will be created if 'exists' is false.
+            NOTE: By default, the creating user will be the owner of the project.
+            However, this group will own the project going forward. Make sure to include
+            yourselve in the group,
           EOF
-          type        = "array"
-          items = {
-            type = "string"
+          type        = "object"
+          additionalProperties = false
+          required = [
+            "id",
+          ]
+          properties = {
+            id = {
+              description = "Email address of the group."
+              type        = "string"
+            }
+            exists = {
+              description = "Whether or not the group exists already. Default to 'false'."
+              type        = "boolean"
+            }
+            customer_id = {
+              description = <<EOF
+                Customer ID of the organization to create the group in.
+                See <https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains#retrieving_customer_id>
+                for how to obtain it.
+              EOF
+              type        = "string"
+            }
+            description = {
+              description = "Description of the group."
+              type        = "string"
+            }
+            display_name = {
+              description = "Display name of the group."
+              type        = "string"
+            }
+            owners = {
+              description = "Owners of the group."
+              type        = "array"
+              items = {
+                type = "string"
+              }
+            }
+            managers = {
+              description = "Managers of the group."
+              type        = "array"
+              items = {
+                type = "string"
+              }
+            }
+            members = {
+              description = "Members of the group."
+              type        = "array"
+              items = {
+                type = "string"
+              }
+            }
           }
         }
         apis = {
@@ -77,8 +134,62 @@ schema = {
       type        = "string"
     }
     admins_group = {
-      description = "Group who will be given org admin access."
-      type        = "string"
+      description = <<EOF
+        Group which will be given admin access to the folder or organization.
+        It will be created if 'exists' is false.
+      EOF
+      type        = "object"
+      additionalProperties = false
+      required = [
+        "id",
+      ]
+      properties = {
+        id = {
+          description = "Email address of the group."
+          type        = "string"
+        }
+        exists = {
+          description = "Whether or not the group exists already. Default to 'false'."
+          type        = "boolean"
+        }
+        customer_id = {
+          description = <<EOF
+            Customer ID of the organization to create the group in.
+            See <https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains#retrieving_customer_id>
+            for how to obtain it.
+          EOF
+          type        = "string"
+        }
+        description = {
+          description = "Description of the group."
+          type        = "string"
+        }
+        display_name = {
+          description = "Display name of the group."
+          type        = "string"
+        }
+        owners = {
+          description = "Owners of the group."
+          type        = "array"
+          items = {
+            type = "string"
+          }
+        }
+        managers = {
+          description = "Managers of the group."
+          type        = "array"
+          items = {
+            type = "string"
+          }
+        }
+        members = {
+          description = "Members of the group."
+          type        = "array"
+          items = {
+            type = "string"
+          }
+        }
+      }
     }
     enable_gcs_backend = {
       description = <<EOF

--- a/templates/tfengine/recipes/resources.hcl
+++ b/templates/tfengine/recipes/resources.hcl
@@ -1318,8 +1318,13 @@ schema = {
     groups = {
       description = "[Module](https://github.com/terraform-google-modules/terraform-google-group)"
       type        = "array"
-      additionalProperties = false
       items = {
+        type                 = "object"
+        additionalProperties = false
+        required = [
+          "id",
+          "customer_id",
+        ]
         properties = {
           id = {
             description = "Email address of the group."


### PR DESCRIPTION
#688

Fixes #689

Creating groups in `devops` cannot be used until Terraform 0.13 is supported.

Creating groups outside of `devops` using the `project.hcl` recipe can be used now.