### PR TITLE
always enable cloud identity api in devops

### DIFF
--- a/examples/tfengine/generated/devops/devops/main.tf
+++ b/examples/tfengine/generated/devops/devops/main.tf
@@ -42,6 +42,7 @@ module "project" {
   default_service_account = "keep"
   activate_apis = [
     "cloudbuild.googleapis.com",
+    "cloudidentity.googleapis.com",
   ]
 }
 

--- a/examples/tfengine/generated/folder_foundation/devops/main.tf
+++ b/examples/tfengine/generated/folder_foundation/devops/main.tf
@@ -43,6 +43,7 @@ module "project" {
   default_service_account = "keep"
   activate_apis = [
     "cloudbuild.googleapis.com",
+    "cloudidentity.googleapis.com",
   ]
 }
 

--- a/examples/tfengine/generated/multi_envs/devops/main.tf
+++ b/examples/tfengine/generated/multi_envs/devops/main.tf
@@ -49,6 +49,7 @@ module "project" {
   default_service_account = "keep"
   activate_apis = [
     "cloudbuild.googleapis.com",
+    "cloudidentity.googleapis.com",
   ]
 }
 

--- a/examples/tfengine/generated/org_foundation/devops/main.tf
+++ b/examples/tfengine/generated/org_foundation/devops/main.tf
@@ -42,6 +42,7 @@ module "project" {
   default_service_account = "keep"
   activate_apis = [
     "cloudbuild.googleapis.com",
+    "cloudidentity.googleapis.com",
   ]
 }
 

--- a/examples/tfengine/generated/team/devops/main.tf
+++ b/examples/tfengine/generated/team/devops/main.tf
@@ -43,6 +43,7 @@ module "project" {
   default_service_account = "keep"
   activate_apis = [
     "cloudbuild.googleapis.com",
+    "cloudidentity.googleapis.com",
     "container.googleapis.com",
     "dns.googleapis.com",
     "healthcare.googleapis.com",

--- a/templates/tfengine/components/devops/main.tf
+++ b/templates/tfengine/components/devops/main.tf
@@ -62,6 +62,7 @@ module "project" {
   default_service_account = "keep"
   activate_apis = [
     "cloudbuild.googleapis.com",
+    "cloudidentity.googleapis.com",
     {{range get . "project.apis" -}}
     "{{.}}",
     {{end -}}


### PR DESCRIPTION
It's needed for group creation in devops template or other templates
whose billing project is set to devops project. Always enable it to
simply the code and logic similar to cloud build api is always enabled
in devops.