### PR TITLE
improve groups doc and display name setting

### DIFF
--- a/docs/tfengine/README.md
+++ b/docs/tfengine/README.md
@@ -340,22 +340,14 @@ directly use the `terraform` binary to deploy the infrastructure.
     [here](../../templates/tfengine/components/cicd/README.md) or equivalently,
     `$OUTPUT_PATH/cicd/README.md` in the generated Terraform configs directory.
 
+    Note that the `groups` template must be deployed manually first if you also
+    use it to create groups to be used in the `cicd` template. These groups
+    should exist before `cicd` template can be deployed.
+
     Your devops project and CICD pipelines are ready. The following changes
     should be made as Pull Requests (PRs) and go though code reviews. After
     approval is granted and CI tests pass, merge the PR. The CD job
     automatically deploys the change to your Google Cloud infra.
-
-    If you would like to enable CICD to manage groups for you:
-
-    1. Include `groups` in the `managed_dirs` of `cicd` template.
-    1. Follow manual steps
-        [here](https://cloud.google.com/identity/docs/how-to/setup#assigning_an_admin_role_to_the_service_account)
-        to assign the CICD service account Group Admin role. You must be a
-        Google Workspace Super Admin to be able to do so.
-
-    Note that the `groups` template must be deployed manually first if you also
-    use it to create groups to be used in the `cicd` template. These groups
-    should exist before `cicd` template can be deployed.
 
 1. Deploy org infrastructure and other resources by sending a PR for local
     changes to the config repo.

--- a/examples/tfengine/generated/devops/cicd/README.md
+++ b/examples/tfengine/generated/devops/cicd/README.md
@@ -33,11 +33,27 @@ to detect changes in the repo, trigger builds, and run the workloads.
     terraform apply
     ```
 
-1. (Optional) Follow the steps
-    [here](https://cloud.google.com/identity/docs/how-to/setup#assigning_an_admin_role_to_the_service_account)
-    to grant **Google Workspace Group Admin** role to the CICD service account
-    so CICD can create and manage groups and memberships for you. You must be a
-    **Google Workspace Super Admin** to be able to do so.
+1. In addition, if you would like to enable CICD to manage groups and
+    memberships for you:
+
+    1. Make sure output directories which contain the groups resources are
+        included in the `managed_dirs` list in the `cicd` template.
+    1. Grant **Google Workspace Group Admin** role to the CICD service account
+        `<devops-project-number>@cloudbuild.gserviceaccount.com` by following
+        the following steps:
+
+        1. Go to Google Admin console's Admin roles configuration page
+            <https://admin.google.com/u/1/ac/roles>
+        1. Click `Groups Admin`;
+        1. Click `Admins assigned`;
+        1. Click `Assign service accounts` and input the CICD service account
+            email address.
+
+    Alternatively, follow steps
+    [here](https://cloud.google.com/identity/docs/how-to/setup#assigning_an_admin_role_to_the_service_account).
+
+    In either approach, you must be a **Google Workspace Super Admin** to be
+    able to complete those steps.
 
 ## CICD Container
 

--- a/examples/tfengine/generated/devops/groups/main.tf
+++ b/examples/tfengine/generated/devops/groups/main.tf
@@ -34,14 +34,18 @@ module "example_cicd_viewers_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-cicd-viewers@example.com"
-  customer_id = "c12345678"
+  id           = "example-cicd-viewers@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-cicd-viewers"
+
 }
 
 module "example_cicd_editors_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-cicd-editors@example.com"
-  customer_id = "c12345678"
+  id           = "example-cicd-editors@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-cicd-editors"
+
 }

--- a/examples/tfengine/generated/devops/groups/main.tf
+++ b/examples/tfengine/generated/devops/groups/main.tf
@@ -37,7 +37,6 @@ module "example_cicd_viewers_example_com" {
   id           = "example-cicd-viewers@example.com"
   customer_id  = "c12345678"
   display_name = "example-cicd-viewers"
-
 }
 
 module "example_cicd_editors_example_com" {
@@ -47,5 +46,4 @@ module "example_cicd_editors_example_com" {
   id           = "example-cicd-editors@example.com"
   customer_id  = "c12345678"
   display_name = "example-cicd-editors"
-
 }

--- a/examples/tfengine/generated/folder_foundation/cicd/README.md
+++ b/examples/tfengine/generated/folder_foundation/cicd/README.md
@@ -33,11 +33,27 @@ to detect changes in the repo, trigger builds, and run the workloads.
     terraform apply
     ```
 
-1. (Optional) Follow the steps
-    [here](https://cloud.google.com/identity/docs/how-to/setup#assigning_an_admin_role_to_the_service_account)
-    to grant **Google Workspace Group Admin** role to the CICD service account
-    so CICD can create and manage groups and memberships for you. You must be a
-    **Google Workspace Super Admin** to be able to do so.
+1. In addition, if you would like to enable CICD to manage groups and
+    memberships for you:
+
+    1. Make sure output directories which contain the groups resources are
+        included in the `managed_dirs` list in the `cicd` template.
+    1. Grant **Google Workspace Group Admin** role to the CICD service account
+        `<devops-project-number>@cloudbuild.gserviceaccount.com` by following
+        the following steps:
+
+        1. Go to Google Admin console's Admin roles configuration page
+            <https://admin.google.com/u/1/ac/roles>
+        1. Click `Groups Admin`;
+        1. Click `Admins assigned`;
+        1. Click `Assign service accounts` and input the CICD service account
+            email address.
+
+    Alternatively, follow steps
+    [here](https://cloud.google.com/identity/docs/how-to/setup#assigning_an_admin_role_to_the_service_account).
+
+    In either approach, you must be a **Google Workspace Super Admin** to be
+    able to complete those steps.
 
 ## CICD Container
 

--- a/examples/tfengine/generated/folder_foundation/groups/main.tf
+++ b/examples/tfengine/generated/folder_foundation/groups/main.tf
@@ -34,24 +34,30 @@ module "example_auditors_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-auditors@example.com"
-  customer_id = "c12345678"
-  owners      = ["user1@example.com"]
-  members     = ["user2@example.com"]
+  id           = "example-auditors@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-auditors"
+
+  owners  = ["user1@example.com"]
+  members = ["user2@example.com"]
 }
 
 module "example_cicd_viewers_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-cicd-viewers@example.com"
-  customer_id = "c12345678"
+  id           = "example-cicd-viewers@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-cicd-viewers"
+
 }
 
 module "example_cicd_editors_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-cicd-editors@example.com"
-  customer_id = "c12345678"
+  id           = "example-cicd-editors@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-cicd-editors"
+
 }

--- a/examples/tfengine/generated/folder_foundation/groups/main.tf
+++ b/examples/tfengine/generated/folder_foundation/groups/main.tf
@@ -37,9 +37,8 @@ module "example_auditors_example_com" {
   id           = "example-auditors@example.com"
   customer_id  = "c12345678"
   display_name = "example-auditors"
-
-  owners  = ["user1@example.com"]
-  members = ["user2@example.com"]
+  owners       = ["user1@example.com"]
+  members      = ["user2@example.com"]
 }
 
 module "example_cicd_viewers_example_com" {
@@ -49,7 +48,6 @@ module "example_cicd_viewers_example_com" {
   id           = "example-cicd-viewers@example.com"
   customer_id  = "c12345678"
   display_name = "example-cicd-viewers"
-
 }
 
 module "example_cicd_editors_example_com" {
@@ -59,5 +57,4 @@ module "example_cicd_editors_example_com" {
   id           = "example-cicd-editors@example.com"
   customer_id  = "c12345678"
   display_name = "example-cicd-editors"
-
 }

--- a/examples/tfengine/generated/multi_envs/cicd/README.md
+++ b/examples/tfengine/generated/multi_envs/cicd/README.md
@@ -33,11 +33,27 @@ to detect changes in the repo, trigger builds, and run the workloads.
     terraform apply
     ```
 
-1. (Optional) Follow the steps
-    [here](https://cloud.google.com/identity/docs/how-to/setup#assigning_an_admin_role_to_the_service_account)
-    to grant **Google Workspace Group Admin** role to the CICD service account
-    so CICD can create and manage groups and memberships for you. You must be a
-    **Google Workspace Super Admin** to be able to do so.
+1. In addition, if you would like to enable CICD to manage groups and
+    memberships for you:
+
+    1. Make sure output directories which contain the groups resources are
+        included in the `managed_dirs` list in the `cicd` template.
+    1. Grant **Google Workspace Group Admin** role to the CICD service account
+        `<devops-project-number>@cloudbuild.gserviceaccount.com` by following
+        the following steps:
+
+        1. Go to Google Admin console's Admin roles configuration page
+            <https://admin.google.com/u/1/ac/roles>
+        1. Click `Groups Admin`;
+        1. Click `Admins assigned`;
+        1. Click `Assign service accounts` and input the CICD service account
+            email address.
+
+    Alternatively, follow steps
+    [here](https://cloud.google.com/identity/docs/how-to/setup#assigning_an_admin_role_to_the_service_account).
+
+    In either approach, you must be a **Google Workspace Super Admin** to be
+    able to complete those steps.
 
 ## CICD Container
 

--- a/examples/tfengine/generated/multi_envs/devops/main.tf
+++ b/examples/tfengine/generated/multi_envs/devops/main.tf
@@ -71,8 +71,7 @@ module "owners_group" {
   id           = "example-devops-owners@example.com"
   customer_id  = "c12345678"
   display_name = "example-devops-owners"
-
-  owners = ["user1@example.com"]
+  owners       = ["user1@example.com"]
   depends_on = [
     module.project
   ]
@@ -93,8 +92,7 @@ module "admins_group" {
   id           = "example-folder-admins@example.com"
   customer_id  = "c12345678"
   display_name = "Example Folder Admins Group"
-
-  owners = ["user1@example.com"]
+  owners       = ["user1@example.com"]
   depends_on = [
     module.project
   ]

--- a/examples/tfengine/generated/multi_envs/devops/main.tf
+++ b/examples/tfengine/generated/multi_envs/devops/main.tf
@@ -68,9 +68,11 @@ module "owners_group" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-devops-owners@example.com"
-  customer_id = "c12345678"
-  owners      = ["user1@example.com"]
+  id           = "example-devops-owners@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-devops-owners"
+
+  owners = ["user1@example.com"]
   depends_on = [
     module.project
   ]
@@ -83,9 +85,24 @@ resource "google_project_iam_binding" "devops_owners" {
   members = ["group:${module.owners_group.id}"]
 }
 
+# Admins group for at folder level.
+module "admins_group" {
+  source  = "terraform-google-modules/group/google"
+  version = "~> 0.1"
+
+  id           = "example-folder-admins@example.com"
+  customer_id  = "c12345678"
+  display_name = "Example Folder Admins Group"
+
+  owners = ["user1@example.com"]
+  depends_on = [
+    module.project
+  ]
+}
+
 # Admin permission at folder level.
 resource "google_folder_iam_member" "admin" {
   folder = "folders/12345678"
   role   = "roles/resourcemanager.folderAdmin"
-  member = "group:example-folder-admins@example.com"
+  member = "group:${module.admins_group.id}"
 }

--- a/examples/tfengine/generated/multi_envs/groups/main.tf
+++ b/examples/tfengine/generated/multi_envs/groups/main.tf
@@ -37,9 +37,8 @@ module "example_auditors_example_com" {
   id           = "example-auditors@example.com"
   customer_id  = "c12345678"
   display_name = "example-auditors"
-
-  owners  = ["user1@example.com"]
-  members = ["user2@example.com"]
+  owners       = ["user1@example.com"]
+  members      = ["user2@example.com"]
 }
 
 module "example_cicd_viewers_example_com" {
@@ -49,7 +48,6 @@ module "example_cicd_viewers_example_com" {
   id           = "example-cicd-viewers@example.com"
   customer_id  = "c12345678"
   display_name = "example-cicd-viewers"
-
 }
 
 module "example_cicd_editors_example_com" {
@@ -59,7 +57,6 @@ module "example_cicd_editors_example_com" {
   id           = "example-cicd-editors@example.com"
   customer_id  = "c12345678"
   display_name = "example-cicd-editors"
-
 }
 
 module "example_source_readers_example_com" {
@@ -69,7 +66,6 @@ module "example_source_readers_example_com" {
   id           = "example-source-readers@example.com"
   customer_id  = "c12345678"
   display_name = "example-source-readers"
-
 }
 
 module "example_source_writers_example_com" {
@@ -79,5 +75,4 @@ module "example_source_writers_example_com" {
   id           = "example-source-writers@example.com"
   customer_id  = "c12345678"
   display_name = "example-source-writers"
-
 }

--- a/examples/tfengine/generated/multi_envs/groups/main.tf
+++ b/examples/tfengine/generated/multi_envs/groups/main.tf
@@ -36,7 +36,7 @@ module "example_auditors_example_com" {
 
   id           = "example-auditors@example.com"
   customer_id  = "c12345678"
-  display_name = "example-auditors"
+  display_name = "Example Auditors Group"
   owners       = ["user1@example.com"]
   members      = ["user2@example.com"]
 }

--- a/examples/tfengine/generated/multi_envs/groups/main.tf
+++ b/examples/tfengine/generated/multi_envs/groups/main.tf
@@ -34,40 +34,50 @@ module "example_auditors_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-auditors@example.com"
-  customer_id = "c12345678"
-  owners      = ["user1@example.com"]
-  members     = ["user2@example.com"]
+  id           = "example-auditors@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-auditors"
+
+  owners  = ["user1@example.com"]
+  members = ["user2@example.com"]
 }
 
 module "example_cicd_viewers_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-cicd-viewers@example.com"
-  customer_id = "c12345678"
+  id           = "example-cicd-viewers@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-cicd-viewers"
+
 }
 
 module "example_cicd_editors_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-cicd-editors@example.com"
-  customer_id = "c12345678"
+  id           = "example-cicd-editors@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-cicd-editors"
+
 }
 
 module "example_source_readers_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-source-readers@example.com"
-  customer_id = "c12345678"
+  id           = "example-source-readers@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-source-readers"
+
 }
 
 module "example_source_writers_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-source-writers@example.com"
-  customer_id = "c12345678"
+  id           = "example-source-writers@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-source-writers"
+
 }

--- a/examples/tfengine/generated/org_foundation/cicd/README.md
+++ b/examples/tfengine/generated/org_foundation/cicd/README.md
@@ -33,11 +33,27 @@ to detect changes in the repo, trigger builds, and run the workloads.
     terraform apply
     ```
 
-1. (Optional) Follow the steps
-    [here](https://cloud.google.com/identity/docs/how-to/setup#assigning_an_admin_role_to_the_service_account)
-    to grant **Google Workspace Group Admin** role to the CICD service account
-    so CICD can create and manage groups and memberships for you. You must be a
-    **Google Workspace Super Admin** to be able to do so.
+1. In addition, if you would like to enable CICD to manage groups and
+    memberships for you:
+
+    1. Make sure output directories which contain the groups resources are
+        included in the `managed_dirs` list in the `cicd` template.
+    1. Grant **Google Workspace Group Admin** role to the CICD service account
+        `<devops-project-number>@cloudbuild.gserviceaccount.com` by following
+        the following steps:
+
+        1. Go to Google Admin console's Admin roles configuration page
+            <https://admin.google.com/u/1/ac/roles>
+        1. Click `Groups Admin`;
+        1. Click `Admins assigned`;
+        1. Click `Assign service accounts` and input the CICD service account
+            email address.
+
+    Alternatively, follow steps
+    [here](https://cloud.google.com/identity/docs/how-to/setup#assigning_an_admin_role_to_the_service_account).
+
+    In either approach, you must be a **Google Workspace Super Admin** to be
+    able to complete those steps.
 
 ## CICD Container
 

--- a/examples/tfengine/generated/org_foundation/groups/main.tf
+++ b/examples/tfengine/generated/org_foundation/groups/main.tf
@@ -34,24 +34,30 @@ module "example_auditors_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-auditors@example.com"
-  customer_id = "c12345678"
-  owners      = ["user1@example.com"]
-  members     = ["user2@example.com"]
+  id           = "example-auditors@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-auditors"
+
+  owners  = ["user1@example.com"]
+  members = ["user2@example.com"]
 }
 
 module "example_cicd_viewers_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-cicd-viewers@example.com"
-  customer_id = "c12345678"
+  id           = "example-cicd-viewers@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-cicd-viewers"
+
 }
 
 module "example_cicd_editors_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-cicd-editors@example.com"
-  customer_id = "c12345678"
+  id           = "example-cicd-editors@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-cicd-editors"
+
 }

--- a/examples/tfengine/generated/org_foundation/groups/main.tf
+++ b/examples/tfengine/generated/org_foundation/groups/main.tf
@@ -37,9 +37,8 @@ module "example_auditors_example_com" {
   id           = "example-auditors@example.com"
   customer_id  = "c12345678"
   display_name = "example-auditors"
-
-  owners  = ["user1@example.com"]
-  members = ["user2@example.com"]
+  owners       = ["user1@example.com"]
+  members      = ["user2@example.com"]
 }
 
 module "example_cicd_viewers_example_com" {
@@ -49,7 +48,6 @@ module "example_cicd_viewers_example_com" {
   id           = "example-cicd-viewers@example.com"
   customer_id  = "c12345678"
   display_name = "example-cicd-viewers"
-
 }
 
 module "example_cicd_editors_example_com" {
@@ -59,5 +57,4 @@ module "example_cicd_editors_example_com" {
   id           = "example-cicd-editors@example.com"
   customer_id  = "c12345678"
   display_name = "example-cicd-editors"
-
 }

--- a/examples/tfengine/generated/team/cicd/README.md
+++ b/examples/tfengine/generated/team/cicd/README.md
@@ -33,11 +33,27 @@ to detect changes in the repo, trigger builds, and run the workloads.
     terraform apply
     ```
 
-1. (Optional) Follow the steps
-    [here](https://cloud.google.com/identity/docs/how-to/setup#assigning_an_admin_role_to_the_service_account)
-    to grant **Google Workspace Group Admin** role to the CICD service account
-    so CICD can create and manage groups and memberships for you. You must be a
-    **Google Workspace Super Admin** to be able to do so.
+1. In addition, if you would like to enable CICD to manage groups and
+    memberships for you:
+
+    1. Make sure output directories which contain the groups resources are
+        included in the `managed_dirs` list in the `cicd` template.
+    1. Grant **Google Workspace Group Admin** role to the CICD service account
+        `<devops-project-number>@cloudbuild.gserviceaccount.com` by following
+        the following steps:
+
+        1. Go to Google Admin console's Admin roles configuration page
+            <https://admin.google.com/u/1/ac/roles>
+        1. Click `Groups Admin`;
+        1. Click `Admins assigned`;
+        1. Click `Assign service accounts` and input the CICD service account
+            email address.
+
+    Alternatively, follow steps
+    [here](https://cloud.google.com/identity/docs/how-to/setup#assigning_an_admin_role_to_the_service_account).
+
+    In either approach, you must be a **Google Workspace Super Admin** to be
+    able to complete those steps.
 
 ## CICD Container
 

--- a/examples/tfengine/generated/team/groups/main.tf
+++ b/examples/tfengine/generated/team/groups/main.tf
@@ -37,7 +37,6 @@ module "example_cicd_viewers_example_com" {
   id           = "example-cicd-viewers@example.com"
   customer_id  = "c12345678"
   display_name = "example-cicd-viewers"
-
 }
 
 module "example_cicd_editors_example_com" {
@@ -47,7 +46,6 @@ module "example_cicd_editors_example_com" {
   id           = "example-cicd-editors@example.com"
   customer_id  = "c12345678"
   display_name = "example-cicd-editors"
-
 }
 
 module "example_apps_viewers_example_com" {
@@ -57,8 +55,7 @@ module "example_apps_viewers_example_com" {
   id           = "example-apps-viewers@example.com"
   customer_id  = "c12345678"
   display_name = "example-apps-viewers"
-
-  owners = ["user1@example.com"]
+  owners       = ["user1@example.com"]
 }
 
 module "example_data_viewers_example_com" {
@@ -68,8 +65,7 @@ module "example_data_viewers_example_com" {
   id           = "example-data-viewers@example.com"
   customer_id  = "c12345678"
   display_name = "example-data-viewers"
-
-  owners = ["user1@example.com"]
+  owners       = ["user1@example.com"]
 }
 
 module "example_healthcare_dataset_viewers_example_com" {
@@ -79,8 +75,7 @@ module "example_healthcare_dataset_viewers_example_com" {
   id           = "example-healthcare-dataset-viewers@example.com"
   customer_id  = "c12345678"
   display_name = "example-healthcare-dataset-viewers"
-
-  owners = ["user1@example.com"]
+  owners       = ["user1@example.com"]
 }
 
 module "example_fhir_viewers_example_com" {
@@ -90,8 +85,7 @@ module "example_fhir_viewers_example_com" {
   id           = "example-fhir-viewers@example.com"
   customer_id  = "c12345678"
   display_name = "example-fhir-viewers"
-
-  owners = ["user1@example.com"]
+  owners       = ["user1@example.com"]
 }
 
 module "bastion_accessors_example_com" {
@@ -101,6 +95,5 @@ module "bastion_accessors_example_com" {
   id           = "bastion-accessors@example.com"
   customer_id  = "c12345678"
   display_name = "bastion-accessors"
-
-  owners = ["user1@example.com"]
+  owners       = ["user1@example.com"]
 }

--- a/examples/tfengine/generated/team/groups/main.tf
+++ b/examples/tfengine/generated/team/groups/main.tf
@@ -34,59 +34,73 @@ module "example_cicd_viewers_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-cicd-viewers@example.com"
-  customer_id = "c12345678"
+  id           = "example-cicd-viewers@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-cicd-viewers"
+
 }
 
 module "example_cicd_editors_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-cicd-editors@example.com"
-  customer_id = "c12345678"
+  id           = "example-cicd-editors@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-cicd-editors"
+
 }
 
 module "example_apps_viewers_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-apps-viewers@example.com"
-  customer_id = "c12345678"
-  owners      = ["user1@example.com"]
+  id           = "example-apps-viewers@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-apps-viewers"
+
+  owners = ["user1@example.com"]
 }
 
 module "example_data_viewers_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-data-viewers@example.com"
-  customer_id = "c12345678"
-  owners      = ["user1@example.com"]
+  id           = "example-data-viewers@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-data-viewers"
+
+  owners = ["user1@example.com"]
 }
 
 module "example_healthcare_dataset_viewers_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-healthcare-dataset-viewers@example.com"
-  customer_id = "c12345678"
-  owners      = ["user1@example.com"]
+  id           = "example-healthcare-dataset-viewers@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-healthcare-dataset-viewers"
+
+  owners = ["user1@example.com"]
 }
 
 module "example_fhir_viewers_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "example-fhir-viewers@example.com"
-  customer_id = "c12345678"
-  owners      = ["user1@example.com"]
+  id           = "example-fhir-viewers@example.com"
+  customer_id  = "c12345678"
+  display_name = "example-fhir-viewers"
+
+  owners = ["user1@example.com"]
 }
 
 module "bastion_accessors_example_com" {
   source  = "terraform-google-modules/group/google"
   version = "~> 0.1"
 
-  id          = "bastion-accessors@example.com"
-  customer_id = "c12345678"
-  owners      = ["user1@example.com"]
+  id           = "bastion-accessors@example.com"
+  customer_id  = "c12345678"
+  display_name = "bastion-accessors"
+
+  owners = ["user1@example.com"]
 }

--- a/examples/tfengine/multi_envs.hcl
+++ b/examples/tfengine/multi_envs.hcl
@@ -37,7 +37,11 @@ template "devops" {
 
     admins_group = {
       id = "example-folder-admins@example.com"
-      exists = true
+      display_name = "Example Folder Admins Group"
+      customer_id = "c12345678"
+      owners = [
+        "user1@example.com"
+      ]
     }
 
     project = {

--- a/examples/tfengine/multi_envs.hcl
+++ b/examples/tfengine/multi_envs.hcl
@@ -72,6 +72,7 @@ template "groups" {
         {
           id = "example-auditors@example.com"
           customer_id = "c12345678"
+          display_name = "Example Auditors Group"
           owners = [
             "user1@example.com"
           ]

--- a/internal/template/funcmap.go
+++ b/internal/template/funcmap.go
@@ -24,15 +24,16 @@ import (
 )
 
 var funcMap = map[string]interface{}{
-	"get":          get,
-	"has":          has,
-	"hcl":          hcl,
-	"hclField":     hclField,
-	"merge":        merge,
-	"replace":      replace,
-	"resourceName": resourceName,
-	"now":          time.Now,
-	"trimSpace":    strings.TrimSpace,
+	"get":             get,
+	"has":             has,
+	"hcl":             hcl,
+	"hclField":        hclField,
+	"merge":           merge,
+	"replace":         replace,
+	"resourceName":    resourceName,
+	"now":             time.Now,
+	"trimSpace":       strings.TrimSpace,
+	"regexReplaceAll": regexReplaceAll,
 }
 
 // invalidIDRE defines the invalid characters not allowed in terraform resource names.
@@ -129,4 +130,12 @@ func resourceName(m map[string]interface{}, key string) (string, error) {
 // alias for strings.Replace with the number of characters fixed to -1 (all).
 func replace(s, old, new string) string {
 	return strings.Replace(s, old, new, -1)
+}
+
+func regexReplaceAll(regex string, s string, repl string) (string, error) {
+	r, err := regexp.Compile(regex)
+	if err != nil {
+		return "", err
+	}
+	return r.ReplaceAllString(s, repl), nil
 }

--- a/templates/tfengine/components/cicd/README.md
+++ b/templates/tfengine/components/cicd/README.md
@@ -33,11 +33,27 @@ to detect changes in the repo, trigger builds, and run the workloads.
     terraform apply
     ```
 
-1. (Optional) Follow the steps
-    [here](https://cloud.google.com/identity/docs/how-to/setup#assigning_an_admin_role_to_the_service_account)
-    to grant **Google Workspace Group Admin** role to the CICD service account
-    so CICD can create and manage groups and memberships for you. You must be a
-    **Google Workspace Super Admin** to be able to do so.
+1. In addition, if you would like to enable CICD to manage groups and
+    memberships for you:
+
+    1. Make sure output directories which contain the groups resources are
+        included in the `managed_dirs` list in the `cicd` template.
+    1. Grant **Google Workspace Group Admin** role to the CICD service account
+        `<devops-project-number>@cloudbuild.gserviceaccount.com` by following
+        the following steps:
+
+        1. Go to Google Admin console's Admin roles configuration page
+            <https://admin.google.com/u/1/ac/roles>
+        1. Click `Groups Admin`;
+        1. Click `Admins assigned`;
+        1. Click `Assign service accounts` and input the CICD service account
+            email address.
+
+    Alternatively, follow steps
+    [here](https://cloud.google.com/identity/docs/how-to/setup#assigning_an_admin_role_to_the_service_account).
+
+    In either approach, you must be a **Google Workspace Super Admin** to be
+    able to complete those steps.
 
 ## CICD Container
 

--- a/templates/tfengine/components/devops/main.tf
+++ b/templates/tfengine/components/devops/main.tf
@@ -88,13 +88,11 @@ module "owners_group" {
 
   id = "{{.project.owners_group.id}}"
   customer_id = "{{.project.owners_group.customer_id}}"
-
   {{- if has .project.owners_group "display_name"}}
   display_name = "{{.project.owners_group.display_name}}"
   {{- else}}
   display_name = "{{regexReplaceAll "@.*" .project.owners_group.id ""}}"
   {{- end}}
-
   {{hclField .project.owners_group "description" -}}
   {{hclField .project.owners_group "owners" -}}
   {{hclField .project.owners_group "managers" -}}
@@ -121,13 +119,11 @@ module "admins_group" {
 
   id = "{{.admins_group.id}}"
   customer_id = "{{.admins_group.customer_id}}"
-
   {{- if has .admins_group "display_name"}}
   display_name = "{{.admins_group.display_name}}"
   {{- else}}
   display_name = "{{regexReplaceAll "@.*" .admins_group.id ""}}"
   {{- end}}
-
   {{hclField .admins_group "description" -}}
   {{hclField .admins_group "owners" -}}
   {{hclField .admins_group "managers" -}}

--- a/templates/tfengine/components/devops/main.tf
+++ b/templates/tfengine/components/devops/main.tf
@@ -88,8 +88,14 @@ module "owners_group" {
 
   id = "{{.project.owners_group.id}}"
   customer_id = "{{.project.owners_group.customer_id}}"
+
+  {{- if has .project.owners_group "display_name"}}
+  display_name = "{{.project.owners_group.display_name}}"
+  {{- else}}
+  display_name = "{{regexReplaceAll "@.*" .project.owners_group.id ""}}"
+  {{- end}}
+
   {{hclField .project.owners_group "description" -}}
-  {{hclField .project.owners_group "display_name" -}}
   {{hclField .project.owners_group "owners" -}}
   {{hclField .project.owners_group "managers" -}}
   {{hclField .project.owners_group "members" -}}
@@ -115,8 +121,14 @@ module "admins_group" {
 
   id = "{{.admins_group.id}}"
   customer_id = "{{.admins_group.customer_id}}"
+
+  {{- if has .admins_group "display_name"}}
+  display_name = "{{.admins_group.display_name}}"
+  {{- else}}
+  display_name = "{{regexReplaceAll "@.*" .admins_group.id ""}}"
+  {{- end}}
+
   {{hclField .admins_group "description" -}}
-  {{hclField .admins_group "display_name" -}}
   {{hclField .admins_group "owners" -}}
   {{hclField .admins_group "managers" -}}
   {{hclField .admins_group "members" -}}

--- a/templates/tfengine/components/resources/groups/main.tf
+++ b/templates/tfengine/components/resources/groups/main.tf
@@ -19,13 +19,11 @@ module "{{resourceName . "id"}}" {
 
   id = "{{.id}}"
   customer_id = "{{.customer_id}}"
-
   {{- if has . "display_name"}}
   display_name = "{{.display_name}}"
   {{- else}}
   display_name = "{{regexReplaceAll "@.*" .id ""}}"
   {{- end}}
-
   {{hclField . "description" -}}
   {{hclField . "owners" -}}
   {{hclField . "managers" -}}

--- a/templates/tfengine/components/resources/groups/main.tf
+++ b/templates/tfengine/components/resources/groups/main.tf
@@ -19,8 +19,14 @@ module "{{resourceName . "id"}}" {
 
   id = "{{.id}}"
   customer_id = "{{.customer_id}}"
+
+  {{- if has . "display_name"}}
+  display_name = "{{.display_name}}"
+  {{- else}}
+  display_name = "{{regexReplaceAll "@.*" .id ""}}"
+  {{- end}}
+
   {{hclField . "description" -}}
-  {{hclField . "display_name" -}}
   {{hclField . "owners" -}}
   {{hclField . "managers" -}}
   {{hclField . "members" -}}


### PR DESCRIPTION
Cloud Identity API will give the display name a default value if not
set. And the next time terraform applies, it will remove that default
name and set to null, which is not as desirable. So we give the same
default display name to the groups.