### PR TITLE
Revert "add caller as default owner in devops groups if none is specified"

### DIFF
--- a/docs/tfengine/schemas/devops.md
+++ b/docs/tfengine/schemas/devops.md
@@ -58,7 +58,6 @@ Type: array(string)
 ### admins_group.owners
 
 Owners of the group.
-If not specified, the caller will be added as the default owner of the group.
 
 Type: array(string)
 
@@ -170,7 +169,6 @@ Type: array(string)
 ### project.owners_group.owners
 
 Owners of the group.
-If not specified, the caller will be added as the default owner of the group.
 
 Type: array(string)
 

--- a/examples/tfengine/generated/multi_envs/devops/main.tf
+++ b/examples/tfengine/generated/multi_envs/devops/main.tf
@@ -36,8 +36,6 @@ provider "google-beta" {
   billing_project       = "example-devops"
 }
 
-data "google_client_openid_userinfo" "caller" {}
-
 # Create the project, enable APIs, and create the deletion lien, if specified.
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
@@ -73,7 +71,7 @@ module "owners_group" {
   id           = "example-devops-owners@example.com"
   customer_id  = "c12345678"
   display_name = "example-devops-owners"
-  owners       = [data.google_client_openid_userinfo.caller.email]
+  owners       = ["user1@example.com"]
   depends_on = [
     module.project
   ]

--- a/examples/tfengine/multi_envs.hcl
+++ b/examples/tfengine/multi_envs.hcl
@@ -49,7 +49,9 @@ template "devops" {
       owners_group = {
         id = "example-devops-owners@example.com"
         customer_id = "c12345678"
-        // No owner specified. The caller will be added as the default owner of the group.
+        owners = [
+          "user1@example.com"
+        ]
       }
     }
   }

--- a/templates/tfengine/components/devops/main.tf
+++ b/templates/tfengine/components/devops/main.tf
@@ -43,8 +43,6 @@ provider "google-beta" {
   user_project_override = true
   billing_project       = "{{.project.project_id}}"
 }
-
-data "google_client_openid_userinfo" "caller" {}
 {{- end}}
 
 # Create the project, enable APIs, and create the deletion lien, if specified.
@@ -96,11 +94,7 @@ module "owners_group" {
   display_name = "{{regexReplaceAll "@.*" .project.owners_group.id ""}}"
   {{- end}}
   {{hclField .project.owners_group "description" -}}
-  {{if has .project.owners_group "owners" -}}
-  owners = {{hcl .project.owners_group.owners -}}
-  {{else -}}
-  owners = [data.google_client_openid_userinfo.caller.email]
-  {{- end}}
+  {{hclField .project.owners_group "owners" -}}
   {{hclField .project.owners_group "managers" -}}
   {{hclField .project.owners_group "members" -}}
   depends_on = [
@@ -131,11 +125,7 @@ module "admins_group" {
   display_name = "{{regexReplaceAll "@.*" .admins_group.id ""}}"
   {{- end}}
   {{hclField .admins_group "description" -}}
-  {{if has .admins_group "owners" -}}
-  owners = {{hcl .admins_group.owners -}}
-  {{else -}}
-  owners = [data.google_client_openid_userinfo.caller.email]
-  {{- end}}
+  {{hclField .admins_group "owners" -}}
   {{hclField .admins_group "managers" -}}
   {{hclField .admins_group "members" -}}
   depends_on = [

--- a/templates/tfengine/recipes/devops.hcl
+++ b/templates/tfengine/recipes/devops.hcl
@@ -92,10 +92,7 @@ schema = {
               type        = "string"
             }
             owners = {
-              description = <<EOF
-                Owners of the group.
-                If not specified, the caller will be added as the default owner of the group.
-              EOF
+              description = "Owners of the group."
               type        = "array"
               items = {
                 type = "string"
@@ -172,10 +169,7 @@ schema = {
           type        = "string"
         }
         owners = {
-          description = <<EOF
-            Owners of the group.
-            If not specified, the caller will be added as the default owner of the group.
-          EOF
+          description = "Owners of the group."
           type        = "array"
           items = {
             type = "string"


### PR DESCRIPTION
Reverts GoogleCloudPlatform/healthcare-data-protection-suite#727

It has an issue. Because the caller is dynamically calculated, whoever tries to redeploy the `devops` recipe (another user, CICD service account) will cause the removal of previous owner from the group and add itself to the group, which is not desirable. Reverting for now.