### PR TITLE
make istio in gke configurable

### DIFF
--- a/docs/tfengine/schemas/resources.md
+++ b/docs/tfengine/schemas/resources.md
@@ -629,6 +629,12 @@ Name of the secondary subnet range to use for services.
 
 Type: string
 
+### gke_clusters.istio
+
+Whether or not to enable Istio addon.
+
+Type: boolean
+
 ### gke_clusters.labels
 
 Labels to set on the cluster.

--- a/examples/tfengine/generated/app/modules/project_apps/main.tf
+++ b/examples/tfengine/generated/app/modules/project_apps/main.tf
@@ -125,7 +125,6 @@ module "example_gke_cluster" {
   ip_range_pods           = "example-pods-range"
   ip_range_services       = "example-services-range"
   master_ipv4_cidr_block  = "192.168.0.0/28"
-  istio                   = true
   skip_provisioners       = true
   enable_private_endpoint = false
   release_channel         = "STABLE"

--- a/examples/tfengine/generated/team/example-prod-apps/main.tf
+++ b/examples/tfengine/generated/team/example-prod-apps/main.tf
@@ -212,7 +212,6 @@ module "example_gke_cluster" {
   ip_range_pods                  = "example-pods-range"
   ip_range_services              = "example-services-range"
   master_ipv4_cidr_block         = "192.168.0.0/28"
-  istio                          = true
   skip_provisioners              = true
   enable_private_endpoint        = false
   release_channel                = "STABLE"

--- a/templates/tfengine/components/resources/gke_clusters/main.tf
+++ b/templates/tfengine/components/resources/gke_clusters/main.tf
@@ -53,7 +53,7 @@ module "{{resourceName . "name"}}" {
   ip_range_services      = "{{.ip_range_services_name}}"
   master_ipv4_cidr_block = "{{.master_ipv4_cidr_block}}"
   {{hclField . "master_authorized_networks" -}}
-  istio                      = true
+  {{hclField . "istio" -}}
   skip_provisioners          = true
   enable_private_endpoint    = false
   release_channel            = "STABLE"

--- a/templates/tfengine/recipes/resources.hcl
+++ b/templates/tfengine/recipes/resources.hcl
@@ -770,6 +770,12 @@ schema = {
             EOF
             type        = "string"
           }
+          istio = {
+            description = <<EOF
+              Whether or not to enable Istio addon.
+            EOF
+            type        = "boolean"
+          }
         }
       }
     }


### PR DESCRIPTION
It's nice to have for microservices. Does not need to be on by default
in all cases. https://cloud.google.com/istio/docs/istio-on-gke/overview

Also see [Should I use Istio on GKE?](https://cloud.google.com/istio/docs/istio-on-gke/overview#should_i_use). "Due to these limitations and the product's beta status, customers should not use this add-on in production. Anthos Service Mesh or open source Istio are better options for production workloads."