### PR TITLE
only use base project factory module

### DIFF
--- a/examples/tfengine/generated/app/modules/project_apps/main.tf
+++ b/examples/tfengine/generated/app/modules/project_apps/main.tf
@@ -24,7 +24,7 @@ locals {
 # Deletion lien: https://cloud.google.com/resource-manager/docs/project-liens
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
-  source  = "terraform-google-modules/project-factory/google//modules/svpc_service_project"
+  source  = "terraform-google-modules/project-factory/google"
   version = "~> 10.0.1"
 
   name                    = "${local.constants.project_prefix}-${local.constants.env_code}-apps"
@@ -34,8 +34,8 @@ module "project" {
   lien                    = true
   default_service_account = "keep"
 
-  shared_vpc    = "${local.constants.project_prefix}-${local.constants.env_code}-networks"
-  activate_apis = ["compute.googleapis.com"]
+  svpc_host_project_id = "${local.constants.project_prefix}-${local.constants.env_code}-networks"
+  activate_apis        = ["compute.googleapis.com"]
 }
 resource "google_binary_authorization_policy" "policy" {
   project = module.project.project_id

--- a/examples/tfengine/generated/app/modules/project_data/main.tf
+++ b/examples/tfengine/generated/app/modules/project_data/main.tf
@@ -24,7 +24,7 @@ locals {
 # Deletion lien: https://cloud.google.com/resource-manager/docs/project-liens
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
-  source  = "terraform-google-modules/project-factory/google//modules/svpc_service_project"
+  source  = "terraform-google-modules/project-factory/google"
   version = "~> 10.0.1"
 
   name                    = "${local.constants.project_prefix}-${local.constants.env_code}-data"
@@ -34,8 +34,8 @@ module "project" {
   lien                    = true
   default_service_account = "keep"
 
-  shared_vpc    = "${local.constants.project_prefix}-${local.constants.env_code}-networks"
-  activate_apis = []
+  svpc_host_project_id = "${local.constants.project_prefix}-${local.constants.env_code}-networks"
+  activate_apis        = []
 }
 
 module "one_billion_ms_example_dataset" {

--- a/examples/tfengine/generated/folder_foundation/monitor/main.tf
+++ b/examples/tfengine/generated/folder_foundation/monitor/main.tf
@@ -28,7 +28,7 @@ terraform {
 # Deletion lien: https://cloud.google.com/resource-manager/docs/project-liens
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
-  source  = "terraform-google-modules/project-factory/google//modules/svpc_service_project"
+  source  = "terraform-google-modules/project-factory/google"
   version = "~> 10.0.1"
 
   name                    = "example-monitor"
@@ -38,8 +38,8 @@ module "project" {
   lien                    = true
   default_service_account = "keep"
 
-  shared_vpc    = "example-prod-networks"
-  activate_apis = ["compute.googleapis.com"]
+  svpc_host_project_id = "example-prod-networks"
+  activate_apis        = ["compute.googleapis.com"]
 }
 
 

--- a/examples/tfengine/generated/org_foundation/monitor/main.tf
+++ b/examples/tfengine/generated/org_foundation/monitor/main.tf
@@ -28,7 +28,7 @@ terraform {
 # Deletion lien: https://cloud.google.com/resource-manager/docs/project-liens
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
-  source  = "terraform-google-modules/project-factory/google//modules/svpc_service_project"
+  source  = "terraform-google-modules/project-factory/google"
   version = "~> 10.0.1"
 
   name                    = "example-monitor"
@@ -37,8 +37,8 @@ module "project" {
   lien                    = true
   default_service_account = "keep"
 
-  shared_vpc    = "example-prod-networks"
-  activate_apis = ["compute.googleapis.com"]
+  svpc_host_project_id = "example-prod-networks"
+  activate_apis        = ["compute.googleapis.com"]
 }
 
 

--- a/examples/tfengine/generated/team/example-prod-apps/main.tf
+++ b/examples/tfengine/generated/team/example-prod-apps/main.tf
@@ -32,7 +32,7 @@ resource "google_compute_address" "static" {
 # Deletion lien: https://cloud.google.com/resource-manager/docs/project-liens
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
-  source  = "terraform-google-modules/project-factory/google//modules/svpc_service_project"
+  source  = "terraform-google-modules/project-factory/google"
   version = "~> 10.0.1"
 
   name                    = "example-prod-apps"
@@ -42,7 +42,7 @@ module "project" {
   lien                    = true
   default_service_account = "keep"
 
-  shared_vpc = "example-prod-networks"
+  svpc_host_project_id = "example-prod-networks"
   shared_vpc_subnets = [
     "projects/example-prod-networks/regions/us-central1/subnetworks/example-gke-subnet",
   ]

--- a/examples/tfengine/generated/team/example-prod-data/main.tf
+++ b/examples/tfengine/generated/team/example-prod-data/main.tf
@@ -28,7 +28,7 @@ terraform {
 # Deletion lien: https://cloud.google.com/resource-manager/docs/project-liens
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
-  source  = "terraform-google-modules/project-factory/google//modules/svpc_service_project"
+  source  = "terraform-google-modules/project-factory/google"
   version = "~> 10.0.1"
 
   name                    = "example-prod-data"
@@ -38,7 +38,7 @@ module "project" {
   lien                    = true
   default_service_account = "keep"
 
-  shared_vpc = "example-prod-networks"
+  svpc_host_project_id = "example-prod-networks"
   activate_apis = [
     "bigquery.googleapis.com",
     "compute.googleapis.com",

--- a/templates/tfengine/components/project/main.tf
+++ b/templates/tfengine/components/project/main.tf
@@ -14,13 +14,8 @@ limitations under the License. */ -}}
 # Deletion lien: https://cloud.google.com/resource-manager/docs/project-liens
 # Shared VPC: https://cloud.google.com/docs/enterprise/best-practices-for-enterprise-organizations#centralize_network_control
 module "project" {
-  {{- if has . "shared_vpc_attachment"}}
-  source  = "terraform-google-modules/project-factory/google//modules/svpc_service_project"
-  version = "~> 10.0.1"
-  {{- else}}
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 10.0.1"
-  {{- end}}
 
   {{- if get . "use_constants"}}
 
@@ -49,7 +44,7 @@ module "project" {
   {{- if has . "shared_vpc_attachment"}}
   {{- if get . "use_constants"}}
   {{$host := printf "${local.constants.project_prefix}-${local.constants.env_code}-%s" .shared_vpc_attachment.host_project_suffix}}
-  shared_vpc              = "{{$host}}"
+  svpc_host_project_id = "{{$host}}"
   {{- if has . "shared_vpc_attachment.subnets"}}
   shared_vpc_subnets = [
     {{- range get . "shared_vpc_attachment.subnets"}}
@@ -59,7 +54,7 @@ module "project" {
   {{- end}}
   {{- else}}
   {{$host := get .shared_vpc_attachment "host_project_id"}}
-  shared_vpc              = "{{$host}}"
+  svpc_host_project_id = "{{$host}}"
   {{- if has . "shared_vpc_attachment.subnets"}}
   shared_vpc_subnets = [
     {{- range get . "shared_vpc_attachment.subnets"}}


### PR DESCRIPTION
Fix #697 

There should actually be no recreation needed because both PF and the service project module have the same module resources and names.