### PR TITLE
upgrade healthcare module to enforce provider version constraint

### DIFF
--- a/examples/tfengine/generated/app/modules/project_data/main.tf
+++ b/examples/tfengine/generated/app/modules/project_data/main.tf
@@ -86,7 +86,7 @@ module "example_mysql_instance" {
 
 module "example_healthcare_dataset" {
   source  = "terraform-google-modules/healthcare/google"
-  version = "~> 1.2.0"
+  version = "~> 1.2.1"
 
   name     = "example-healthcare-dataset"
   project  = module.project.project_id

--- a/examples/tfengine/generated/resources_only/resources/main.tf
+++ b/examples/tfengine/generated/resources_only/resources/main.tf
@@ -59,7 +59,7 @@ module "one_billion_ms_example_dataset" {
 
 module "example_healthcare_dataset" {
   source  = "terraform-google-modules/healthcare/google"
-  version = "~> 1.2.0"
+  version = "~> 1.2.1"
 
   name     = "example-healthcare-dataset"
   project  = module.project.project_id

--- a/examples/tfengine/generated/team/project_data/main.tf
+++ b/examples/tfengine/generated/team/project_data/main.tf
@@ -100,7 +100,7 @@ module "sql_instance" {
 
 module "example_healthcare_dataset" {
   source  = "terraform-google-modules/healthcare/google"
-  version = "~> 1.2.0"
+  version = "~> 1.2.1"
 
   name     = "example-healthcare-dataset"
   project  = module.project.project_id

--- a/templates/tfengine/components/resources/healthcare_datasets/main.tf
+++ b/templates/tfengine/components/resources/healthcare_datasets/main.tf
@@ -15,7 +15,7 @@ limitations under the License. */ -}}
 {{range get . "healthcare_datasets"}}
 module "{{resourceName . "name"}}" {
   source  = "terraform-google-modules/healthcare/google"
-  version = "~> 1.2.0"
+  version = "~> 1.2.1"
 
   name     = "{{.name}}"
   project  = module.project.project_id


### PR DESCRIPTION
google provider v3.54.0 has a critical fix related to creating dataset, need to
pin to healthcare module that enforces that.