### PR TITLE
restrict members and managers from being specified for groups

### DIFF
--- a/docs/tfengine/schemas/devops.md
+++ b/docs/tfengine/schemas/devops.md
@@ -43,18 +43,6 @@ Email address of the group.
 
 Type: string
 
-### admins_group.managers
-
-Managers of the group.
-
-Type: array(string)
-
-### admins_group.members
-
-Members of the group.
-
-Type: array(string)
-
 ### admins_group.owners
 
 Owners of the group.
@@ -153,18 +141,6 @@ Type: boolean
 Email address of the group.
 
 Type: string
-
-### project.owners_group.managers
-
-Managers of the group.
-
-Type: array(string)
-
-### project.owners_group.members
-
-Members of the group.
-
-Type: array(string)
 
 ### project.owners_group.owners
 

--- a/docs/tfengine/schemas/resources.md
+++ b/docs/tfengine/schemas/resources.md
@@ -765,18 +765,6 @@ Email address of the group.
 
 Type: string
 
-### groups.managers
-
-Managers of the group.
-
-Type: array(string)
-
-### groups.members
-
-Members of the group.
-
-Type: array(string)
-
 ### groups.owners
 
 Owners of the group.

--- a/examples/tfengine/folder_foundation.hcl
+++ b/examples/tfengine/folder_foundation.hcl
@@ -68,9 +68,6 @@ template "groups" {
           owners = [
             "user1@example.com"
           ]
-          members = [
-            "user2@example.com"
-          ]
         },
         {
           id = "example-cicd-viewers@example.com"

--- a/examples/tfengine/generated/folder_foundation/groups/main.tf
+++ b/examples/tfengine/generated/folder_foundation/groups/main.tf
@@ -47,7 +47,6 @@ module "example_auditors_example_com" {
   customer_id  = "c12345678"
   display_name = "example-auditors"
   owners       = ["user1@example.com"]
-  members      = ["user2@example.com"]
 }
 
 module "example_cicd_viewers_example_com" {

--- a/examples/tfengine/generated/multi_envs/groups/main.tf
+++ b/examples/tfengine/generated/multi_envs/groups/main.tf
@@ -47,7 +47,6 @@ module "example_auditors_example_com" {
   customer_id  = "c12345678"
   display_name = "Example Auditors Group"
   owners       = ["user1@example.com"]
-  members      = ["user2@example.com"]
 }
 
 module "example_cicd_viewers_example_com" {

--- a/examples/tfengine/generated/org_foundation/groups/main.tf
+++ b/examples/tfengine/generated/org_foundation/groups/main.tf
@@ -47,7 +47,6 @@ module "example_auditors_example_com" {
   customer_id  = "c12345678"
   display_name = "example-auditors"
   owners       = ["user1@example.com"]
-  members      = ["user2@example.com"]
 }
 
 module "example_cicd_viewers_example_com" {

--- a/examples/tfengine/multi_envs.hcl
+++ b/examples/tfengine/multi_envs.hcl
@@ -76,9 +76,6 @@ template "groups" {
           owners = [
             "user1@example.com"
           ]
-          members = [
-            "user2@example.com"
-          ]
         },
         {
           id = "example-cicd-viewers@example.com"

--- a/examples/tfengine/org_foundation.hcl
+++ b/examples/tfengine/org_foundation.hcl
@@ -68,9 +68,6 @@ template "groups" {
           owners = [
             "user1@example.com"
           ]
-          members = [
-            "user2@example.com"
-          ]
         },
         {
           id = "example-cicd-viewers@example.com"

--- a/templates/tfengine/recipes/devops.hcl
+++ b/templates/tfengine/recipes/devops.hcl
@@ -99,20 +99,23 @@ schema = {
                 type = "string"
               }
             }
-            managers = {
-              description = "Managers of the group."
-              type        = "array"
-              items = {
-                type = "string"
-              }
-            }
-            members = {
-              description = "Members of the group."
-              type        = "array"
-              items = {
-                type = "string"
-              }
-            }
+            # Due to limitations in the underlying module, managers and members
+            # are not supported and should be configured in the Google Workspace
+            # Admin console.
+            # managers = {
+            #   description = "Managers of the group."
+            #   type        = "array"
+            #   items = {
+            #     type = "string"
+            #   }
+            # }
+            # members = {
+            #   description = "Members of the group."
+            #   type        = "array"
+            #   items = {
+            #     type = "string"
+            #   }
+            # }
           }
         }
         apis = {
@@ -176,20 +179,23 @@ schema = {
             type = "string"
           }
         }
-        managers = {
-          description = "Managers of the group."
-          type        = "array"
-          items = {
-            type = "string"
-          }
-        }
-        members = {
-          description = "Members of the group."
-          type        = "array"
-          items = {
-            type = "string"
-          }
-        }
+        # Due to limitations in the underlying module, managers and members
+        # are not supported and should be configured in the Google Workspace
+        # Admin console.
+        # managers = {
+        #   description = "Managers of the group."
+        #   type        = "array"
+        #   items = {
+        #     type = "string"
+        #   }
+        # }
+        # members = {
+        #   description = "Members of the group."
+        #   type        = "array"
+        #   items = {
+        #     type = "string"
+        #   }
+        # }
       }
     }
     enable_gcs_backend = {

--- a/templates/tfengine/recipes/resources.hcl
+++ b/templates/tfengine/recipes/resources.hcl
@@ -1382,20 +1382,23 @@ schema = {
               type = "string"
             }
           }
-          managers = {
-            description = "Managers of the group."
-            type        = "array"
-            items = {
-              type = "string"
-            }
-          }
-          members = {
-            description = "Members of the group."
-            type        = "array"
-            items = {
-              type = "string"
-            }
-          }
+          # Due to limitations in the underlying module, managers and members
+          # are not supported and should be configured in the Google Workspace
+          # Admin console.
+          # managers = {
+          #   description = "Managers of the group."
+          #   type        = "array"
+          #   items = {
+          #     type = "string"
+          #   }
+          # }
+          # members = {
+          #   description = "Members of the group."
+          #   type        = "array"
+          #   items = {
+          #     type = "string"
+          #   }
+          # }
         }
       }
     }


### PR DESCRIPTION
This is aligned with documentation in docs/tfengine/README.md. Enforce
it in templates as well.

Underlying issues: https://github.com/terraform-google-modules/terraform-google-group#limitations