### PR TITLE
Use basename for plan file

### DIFF
--- a/internal/tfimport/tfimport.go
+++ b/internal/tfimport/tfimport.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path"
 	"regexp"
 	"strings"
 
@@ -576,11 +577,11 @@ func planAndImport(rn, importRn runner.Runner, runArgs *RunArgs) (retry bool, er
 		return false, fmt.Errorf("create temp file: %v", err)
 	}
 	defer os.Remove(tmpfile.Name())
-	planPath := tmpfile.Name()
-	if out, err := tfCmdOutput("plan", "-out", planPath); err != nil {
+	planName := path.Base(tmpfile.Name())
+	if out, err := tfCmdOutput("plan", "-out", planName); err != nil {
 		return false, fmt.Errorf("plan: %v\n%v", err, string(out))
 	}
-	b, err := tfCmdOutput("show", "-json", planPath)
+	b, err := tfCmdOutput("show", "-json", planName)
 	if err != nil {
 		return false, fmt.Errorf("show: %v\n%v", err, string(b))
 	}


### PR DESCRIPTION
The terraform commands in that function are already running in the InputDir, so we don't need to specify the full path. Seems to not work sometimes.

Fixes #780