### PR TITLE
make healthcare resources explicitly depend on project module to finish

### DIFF
--- a/examples/tfengine/generated/app/modules/project_data/main.tf
+++ b/examples/tfengine/generated/app/modules/project_data/main.tf
@@ -130,6 +130,9 @@ module "example_healthcare_dataset" {
       }
     },
   ]
+  depends_on = [
+    module.project
+  ]
 }
 
 module "project_iam_members" {

--- a/examples/tfengine/generated/resources_only/resources/main.tf
+++ b/examples/tfengine/generated/resources_only/resources/main.tf
@@ -106,6 +106,9 @@ module "example_healthcare_dataset" {
       }
     },
   ]
+  depends_on = [
+    module.project
+  ]
 }
 
 resource "google_service_account" "example_sa" {

--- a/examples/tfengine/generated/team/project_data/main.tf
+++ b/examples/tfengine/generated/team/project_data/main.tf
@@ -181,6 +181,9 @@ EOF
       }
     },
   ]
+  depends_on = [
+    module.project
+  ]
 }
 
 module "project_iam_members" {

--- a/templates/tfengine/components/resources/healthcare_datasets/main.tf
+++ b/templates/tfengine/components/resources/healthcare_datasets/main.tf
@@ -133,5 +133,9 @@ module "{{resourceName . "name"}}" {
     {{end -}}
   ]
   {{end -}}
+
+  depends_on = [
+    module.project
+  ]
 }
 {{end -}}


### PR DESCRIPTION
The current behavior is healthcare module resources will start being
created once the project itself is created and project ID is availale.
This can cause race condition between other resources such as api
identities and fhir store. FHIR store creation should wait for
healthcare api identity permission granting to finish, which is done as
part of the project factory module.

Sample error message is:
Error: Error creating FhirStore: googleapi: Error 403: failed to verify
dataset (projectID:..., datasetID:...),
please add the required bigquery.dataEditor and bigquery.jobUser roles
to your project's service account