### PR TITLE
Importer: Don't manually log error messages

### DIFF
--- a/cmd/tfimport/main.go
+++ b/cmd/tfimport/main.go
@@ -76,13 +76,14 @@ func run() error {
 		return fmt.Errorf("--input_dir must be set and not be empty")
 	}
 	// Determine the runners to use.
-	rn := &runner.Default{}
+	var rn runner.Runner = &runner.Default{}
 	var importRn runner.Runner = &runner.Default{}
 	if *dryRun {
 		importRn = &runner.Dry{}
 		log.Printf("Dry run mode, logging commands but not executing any imports.")
 	} else if *verbose {
 		// Use the Multi runner to print temporary output in case the terraform import command freezes.
+		rn = &runner.Multi{}
 		importRn = &runner.Multi{}
 	}
 

--- a/internal/tfimport/tfimport.go
+++ b/internal/tfimport/tfimport.go
@@ -664,22 +664,22 @@ func planAndImport(rn, importRn runner.Runner, runArgs *RunArgs) (retry bool, er
 
 		// Check if the error indicates insufficient information.
 		case errors.As(err, &ie):
+			log.Printf("Insufficient information to import %q\n", cc.Address)
 			errMsg := fmt.Sprintf("Insufficient information to import %q: %v\n", cc.Address, err)
 			errs = append(errs, errMsg)
-			log.Printf("Skipping: %v\n", errMsg)
 
 		// Check if error indicates resource is not importable or does not exist.
 		// err will be `exit code 1` even when it failed because the resource is not importable or already exists.
 		case NotImportable(output):
-			log.Printf("Import not supported by provider for resource %q\n", ir.Change.Address)
+			log.Printf("Import not supported by provider for resource %q\n", cc.Address)
 		case DoesNotExist(output):
-			log.Printf("Resource %q does not exist, not importing\n", ir.Change.Address)
+			log.Printf("Resource %q does not exist, not importing\n", cc.Address)
 
 		// Important to handle this last.
 		default:
-			errMsg := fmt.Sprintf("failed to import %q: %v\n%v", ir.Change.Address, err, output)
+			log.Printf("Failed to import %q\n", cc.Address)
+			errMsg := fmt.Sprintf("failed to import %q: %v\n%v", cc.Address, err, output)
 			errs = append(errs, errMsg)
-			log.Printf("Skipping: %v\n", errMsg)
 		}
 	}
 
@@ -704,7 +704,7 @@ func planAndImport(rn, importRn runner.Runner, runArgs *RunArgs) (retry bool, er
 			return true, nil
 		}
 		// Don't treat manual skips as errors.
-		log.Printf("skipped %d resources:\n%v", len(skipped), strings.Join(skipped, "\n"))
+		log.Printf("Skipped %d resources:\n%v", len(skipped), strings.Join(skipped, "\n"))
 		return false, nil
 	}
 


### PR DESCRIPTION
These will be logged by the runner when using the --verbose flag.

Fixes https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite/issues/788