### PR TITLE
Don't run both plan and apply for CSR

### DIFF
--- a/docs/tfengine/schemas/cicd.md
+++ b/docs/tfengine/schemas/cicd.md
@@ -27,7 +27,7 @@ presubmit runs. If you set both plan and apply to run at the same time,
 they will conflict and may error out. To get around this, for 'shared'
 and 'prod' environment, set 'apply' trigger to not 'run_on_push',
 and for other environments, do not specify the 'plan' trigger block
-and let 'apply' trigger to 'run_on_push'.
+and let 'apply' trigger 'run_on_push'.
 
 Type: object
 

--- a/docs/tfengine/schemas/cicd.md
+++ b/docs/tfengine/schemas/cicd.md
@@ -22,6 +22,12 @@ Type: array(string)
 
 Config for Google Cloud Source Repository Cloud Build triggers.
 
+IMPORTANT: Cloud Source Repositories does not support code review or
+presubmit runs. If you set both plan and apply to run at the same time,
+they will conflict when trying to acquire the lock and may error out.
+To get around this, you should only auto-apply for non-prod envs,
+and only plan for the prod env.
+
 Type: object
 
 ### cloud_source_repository.name

--- a/docs/tfengine/schemas/cicd.md
+++ b/docs/tfengine/schemas/cicd.md
@@ -20,13 +20,12 @@ Type: array(string)
 
 ### cloud_source_repository
 
-Config for Google Cloud Source Repository Cloud Build triggers.
+Config for Google Cloud Source Repository.
 
 IMPORTANT: Cloud Source Repositories does not support code review or
 presubmit runs. If you set both plan and apply to run at the same time,
-they will conflict when trying to acquire the lock and may error out.
-To get around this, you should only auto-apply for non-prod envs,
-and only plan for the prod env.
+they will conflict and may error out. To get around this, you should
+only auto-apply for non-prod envs, and only plan for the prod env.
 
 Type: object
 

--- a/docs/tfengine/schemas/cicd.md
+++ b/docs/tfengine/schemas/cicd.md
@@ -24,8 +24,10 @@ Config for Google Cloud Source Repository.
 
 IMPORTANT: Cloud Source Repositories does not support code review or
 presubmit runs. If you set both plan and apply to run at the same time,
-they will conflict and may error out. To get around this, you should
-only auto-apply for non-prod envs, and only plan for the prod env.
+they will conflict and may error out. To get around this, for 'shared'
+and 'prod' environment, set 'apply' trigger to not 'run_on_push',
+and for other environments, do not specify the 'plan' trigger block
+and let 'apply' trigger to 'run_on_push'.
 
 Type: object
 

--- a/examples/tfengine/generated/multi_envs/cicd/triggers.tf
+++ b/examples/tfengine/generated/multi_envs/cicd/triggers.tf
@@ -43,6 +43,7 @@ resource "google_cloudbuild_trigger" "validate_shared" {
 }
 
 resource "google_cloudbuild_trigger" "plan_shared" {
+  disabled    = true
   provider    = google-beta
   project     = var.project_id
   name        = "tf-plan-shared"
@@ -129,6 +130,7 @@ resource "google_cloudbuild_trigger" "validate_dev" {
 }
 
 resource "google_cloudbuild_trigger" "plan_dev" {
+  disabled    = true
   provider    = google-beta
   project     = var.project_id
   name        = "tf-plan-dev"

--- a/examples/tfengine/generated/multi_envs/cicd/triggers.tf
+++ b/examples/tfengine/generated/multi_envs/cicd/triggers.tf
@@ -129,35 +129,6 @@ resource "google_cloudbuild_trigger" "validate_dev" {
   ]
 }
 
-resource "google_cloudbuild_trigger" "plan_dev" {
-  disabled    = true
-  provider    = google-beta
-  project     = var.project_id
-  name        = "tf-plan-dev"
-  description = "Terraform plan job triggered on push event."
-
-  included_files = [
-    "terraform/**",
-  ]
-
-  trigger_template {
-    repo_name   = "example"
-    branch_name = "^dev$"
-  }
-
-  filename = "terraform/cicd/configs/tf-plan.yaml"
-
-  substitutions = {
-    _TERRAFORM_ROOT = "terraform"
-    _MANAGED_DIRS   = "dev/data"
-  }
-
-  depends_on = [
-    google_project_service.services,
-    google_sourcerepo_repository.configs,
-  ]
-}
-
 resource "google_cloudbuild_trigger" "apply_dev" {
   provider    = google-beta
   project     = var.project_id

--- a/examples/tfengine/generated/multi_envs/cicd/triggers.tf
+++ b/examples/tfengine/generated/multi_envs/cicd/triggers.tf
@@ -43,7 +43,6 @@ resource "google_cloudbuild_trigger" "validate_shared" {
 }
 
 resource "google_cloudbuild_trigger" "plan_shared" {
-  disabled    = true
   provider    = google-beta
   project     = var.project_id
   name        = "tf-plan-shared"
@@ -72,6 +71,7 @@ resource "google_cloudbuild_trigger" "plan_shared" {
 }
 
 resource "google_cloudbuild_trigger" "apply_shared" {
+  disabled    = true
   provider    = google-beta
   project     = var.project_id
   name        = "tf-apply-shared"

--- a/examples/tfengine/multi_envs.hcl
+++ b/examples/tfengine/multi_envs.hcl
@@ -123,18 +123,20 @@ template "cicd" {
 
     # IMPORTANT: Cloud Source Repositories does not support code review or
     # presubmit runs. If we set both plan and apply to run at the same time,
-    # they will conflict and may error out. To get around this, below we only
-    # auto-apply for non-prod envs and only plan for the prod env.
+	  # they will conflict and may error out. To get around this, for 'shared'
+	  # and 'prod' environment, set 'apply' trigger to not 'run_on_push',
+	  # and for other environments, do not specify the 'plan' trigger block
+	  # and let 'apply' trigger to 'run_on_push'.
     envs = [
       {
         name        = "shared"
         branch_name = "shared"
         triggers = {
           validate = {}
-          plan = {
+          plan = {}
+          apply = {
             run_on_push = false # Do not auto run on push to CSR non-prod branch
           }
-          apply = {}
         }
         managed_dirs = [
           "groups",

--- a/examples/tfengine/multi_envs.hcl
+++ b/examples/tfengine/multi_envs.hcl
@@ -135,7 +135,7 @@ template "cicd" {
           validate = {}
           plan = {}
           apply = {
-            run_on_push = false # Do not auto run on push to CSR non-prod branch
+            run_on_push = false # Do not 'apply' trigger on push to CSR 'shared' branch
           }
         }
         managed_dirs = [
@@ -149,9 +149,6 @@ template "cicd" {
         branch_name = "dev"
         triggers = {
           validate = {}
-          plan = {
-            run_on_push = false # Do not auto run on push to CSR non-prod branch
-          }
           apply = {}
         }
         managed_dirs = [
@@ -165,7 +162,7 @@ template "cicd" {
           validate = {}
           plan = {}
           apply = {
-            run_on_push = false # Do not auto run on push to prod branch
+            run_on_push = false # Do not 'apply' trigger on push to CSR 'prod' branch
           }
         }
         managed_dirs = [

--- a/examples/tfengine/multi_envs.hcl
+++ b/examples/tfengine/multi_envs.hcl
@@ -123,10 +123,10 @@ template "cicd" {
 
     # IMPORTANT: Cloud Source Repositories does not support code review or
     # presubmit runs. If we set both plan and apply to run at the same time,
-	  # they will conflict and may error out. To get around this, for 'shared'
-	  # and 'prod' environment, set 'apply' trigger to not 'run_on_push',
-	  # and for other environments, do not specify the 'plan' trigger block
-	  # and let 'apply' trigger to 'run_on_push'.
+    # they will conflict and may error out. To get around this, for 'shared'
+    # and 'prod' environment, set 'apply' trigger to not 'run_on_push',
+    # and for other environments, do not specify the 'plan' trigger block
+    # and let 'apply' trigger 'run_on_push'.
     envs = [
       {
         name        = "shared"
@@ -135,7 +135,7 @@ template "cicd" {
           validate = {}
           plan = {}
           apply = {
-            run_on_push = false # Do not 'apply' trigger on push to CSR 'shared' branch
+            run_on_push = false # Do not 'apply' on push to CSR 'shared' branch
           }
         }
         managed_dirs = [
@@ -162,7 +162,7 @@ template "cicd" {
           validate = {}
           plan = {}
           apply = {
-            run_on_push = false # Do not 'apply' trigger on push to CSR 'prod' branch
+            run_on_push = false # Do not 'apply' on push to CSR 'prod' branch
           }
         }
         managed_dirs = [

--- a/examples/tfengine/multi_envs.hcl
+++ b/examples/tfengine/multi_envs.hcl
@@ -122,10 +122,9 @@ template "cicd" {
     terraform_root = "terraform"
 
     # IMPORTANT: Cloud Source Repositories does not support code review or
-    #   presubmit runs. If we set both plan and apply to run at the same time,
-    #   they will conflict when trying to acquire the lock and may error out.
-    #   To get around this, below we only auto-apply for non-prod envs,
-    #   and only plan for the prod env.
+    # presubmit runs. If we set both plan and apply to run at the same time,
+    # they will conflict and may error out. To get around this, below we only
+    # auto-apply for non-prod envs and only plan for the prod env.
     envs = [
       {
         name        = "shared"

--- a/examples/tfengine/multi_envs.hcl
+++ b/examples/tfengine/multi_envs.hcl
@@ -120,13 +120,21 @@ template "cicd" {
     build_editors = ["group:example-cicd-editors@example.com"]
 
     terraform_root = "terraform"
+
+    # IMPORTANT: Cloud Source Repositories does not support code review or
+    #   presubmit runs. If we set both plan and apply to run at the same time,
+    #   they will conflict when trying to acquire the lock and may error out.
+    #   To get around this, below we only auto-apply for non-prod envs,
+    #   and only plan for the prod env.
     envs = [
       {
         name        = "shared"
         branch_name = "shared"
         triggers = {
           validate = {}
-          plan = {}
+          plan = {
+            run_on_push = false # Do not auto run on push to CSR non-prod branch
+          }
           apply = {}
         }
         managed_dirs = [
@@ -140,7 +148,9 @@ template "cicd" {
         branch_name = "dev"
         triggers = {
           validate = {}
-          plan = {}
+          plan = {
+            run_on_push = false # Do not auto run on push to CSR non-prod branch
+          }
           apply = {}
         }
         managed_dirs = [

--- a/templates/tfengine/components/cicd/main.tf
+++ b/templates/tfengine/components/cicd/main.tf
@@ -26,7 +26,7 @@
 {{- $hasScheduledJobs := false}}
 {{- $hasApplyJobs := false}}
 {{- range .envs}}
-  {{- if or (has .triggers.validate "run_on_schedule") (has .triggers.plan "run_on_schedule") (has .triggers.apply "run_on_schedule")}}
+  {{- if or (has .triggers "validate.run_on_schedule") (has .triggers "plan.run_on_schedule") (has .triggers "apply.run_on_schedule")}}
     {{- $hasScheduledJobs = true}}
   {{- end}}
   {{- if has .triggers "apply"}}

--- a/templates/tfengine/recipes/cicd.hcl
+++ b/templates/tfengine/recipes/cicd.hcl
@@ -43,13 +43,12 @@ schema = {
     }
     cloud_source_repository = {
       description          = <<EOF
-        Config for Google Cloud Source Repository Cloud Build triggers.
+        Config for Google Cloud Source Repository.
 
         IMPORTANT: Cloud Source Repositories does not support code review or
         presubmit runs. If you set both plan and apply to run at the same time,
-        they will conflict when trying to acquire the lock and may error out.
-        To get around this, you should only auto-apply for non-prod envs,
-        and only plan for the prod env.
+        they will conflict and may error out. To get around this, you should
+        only auto-apply for non-prod envs, and only plan for the prod env.
       EOF
       type                 = "object"
       additionalProperties = false

--- a/templates/tfengine/recipes/cicd.hcl
+++ b/templates/tfengine/recipes/cicd.hcl
@@ -47,8 +47,10 @@ schema = {
 
         IMPORTANT: Cloud Source Repositories does not support code review or
         presubmit runs. If you set both plan and apply to run at the same time,
-        they will conflict and may error out. To get around this, you should
-        only auto-apply for non-prod envs, and only plan for the prod env.
+        they will conflict and may error out. To get around this, for 'shared'
+        and 'prod' environment, set 'apply' trigger to not 'run_on_push',
+        and for other environments, do not specify the 'plan' trigger block
+        and let 'apply' trigger to 'run_on_push'.
       EOF
       type                 = "object"
       additionalProperties = false

--- a/templates/tfengine/recipes/cicd.hcl
+++ b/templates/tfengine/recipes/cicd.hcl
@@ -50,7 +50,7 @@ schema = {
         they will conflict and may error out. To get around this, for 'shared'
         and 'prod' environment, set 'apply' trigger to not 'run_on_push',
         and for other environments, do not specify the 'plan' trigger block
-        and let 'apply' trigger to 'run_on_push'.
+        and let 'apply' trigger 'run_on_push'.
       EOF
       type                 = "object"
       additionalProperties = false

--- a/templates/tfengine/recipes/cicd.hcl
+++ b/templates/tfengine/recipes/cicd.hcl
@@ -42,7 +42,15 @@ schema = {
       }
     }
     cloud_source_repository = {
-      description          = "Config for Google Cloud Source Repository Cloud Build triggers."
+      description          = <<EOF
+        Config for Google Cloud Source Repository Cloud Build triggers.
+
+        IMPORTANT: Cloud Source Repositories does not support code review or
+        presubmit runs. If you set both plan and apply to run at the same time,
+        they will conflict when trying to acquire the lock and may error out.
+        To get around this, you should only auto-apply for non-prod envs,
+        and only plan for the prod env.
+      EOF
       type                 = "object"
       additionalProperties = false
       required = [


### PR DESCRIPTION
Cloud Source Repositories does not support code review or presubmit runs. If we set both plan and apply to run at the same time, they will conflict when trying to acquire the lock and may error out.

To get around this, set only auto-apply for non-prod envs, and only plan for the prod env.