### PR TITLE
turn release status to stable versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Google Cloud Healthcare Data Protection Suite
 
-Status: Alpha
+Stable releases:
+
+![version](https://img.shields.io/github/v/release/GoogleCloudPlatform/healthcare-data-protection-suite?color=green&label=Binaries&sort=semver)
 
 This repository contains a suite of tools that can be used to manage key areas
 of your Google Cloud organization.


### PR DESCRIPTION
Only adding version badge for binaries for now. I didn't find a way to
filter tags / releases by prefix so I can include badge for templates
and policies as well.