### PR TITLE
Change CICD container to a more secure one.

### DIFF
--- a/examples/tfengine/generated/devops/cicd/README.md
+++ b/examples/tfengine/generated/devops/cicd/README.md
@@ -65,7 +65,7 @@ validate and deploy Terraform configs. If you would like to use a different
 container for production deployment, you can modify the Cloud Build YAML files
 in [./configs](./configs) directory to point to your container.
 
-We leverage Cloud Container Registry's Vulnerability scanning feature to detect
+We leverage Google Container Registry's Vulnerability scanning feature to detect
 potential security risks in this container, and
 [None](https://console.cloud.google.com/gcr/images/cloud-foundation-cicd/global/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011/details?tab=vulnz)
 is reported.

--- a/examples/tfengine/generated/devops/cicd/README.md
+++ b/examples/tfengine/generated/devops/cicd/README.md
@@ -65,6 +65,11 @@ validate and deploy Terraform configs. If you would like to use a different
 container for production deployment, you can modify the Cloud Build YAML files
 in [./configs](./configs) directory to point to your container.
 
+We leverage Cloud Container Registry's Vulnerability scanning feature to detect
+potential security risks in this container, and
+[None](https://console.cloud.google.com/gcr/images/cloud-foundation-cicd/global/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011/details?tab=vulnz)
+is reported.
+
 ## Features
 
 ### Event-triggered builds

--- a/examples/tfengine/generated/devops/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/devops/cicd/configs/tf-apply.yaml
@@ -21,18 +21,18 @@ substitutions:
     _MANAGED_DIRS: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/import.sh", "-d", "${_MANAGED_DIRS}"]
     dir: "${_TERRAFORM_ROOT}"
     id: Import existing projects
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init", "-a", "plan", "-a", "apply -auto-approve"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/devops/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/devops/cicd/configs/tf-plan.yaml
@@ -21,19 +21,19 @@ substitutions:
     _MANAGED_DIRS: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -lock=false", "-a", "plan -lock=false -out=plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"
     id: Speculative plan
 
   # Check for delete operations as an FYI, it won't fail the build.
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/tf-deletion-check.sh", "./cicd/configs/tf-deletion-allowlist.txt"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/devops/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/devops/cicd/configs/tf-validate.yaml
@@ -21,18 +21,18 @@ substitutions:
     _MANAGED_DIRS: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["fmt", "-recursive", "-check"]
     dir: "${_TERRAFORM_ROOT}"
     id: Terraform configs format check
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -backend=false", "-a", "validate"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/folder_foundation/cicd/README.md
+++ b/examples/tfengine/generated/folder_foundation/cicd/README.md
@@ -65,7 +65,7 @@ validate and deploy Terraform configs. If you would like to use a different
 container for production deployment, you can modify the Cloud Build YAML files
 in [./configs](./configs) directory to point to your container.
 
-We leverage Cloud Container Registry's Vulnerability scanning feature to detect
+We leverage Google Container Registry's Vulnerability scanning feature to detect
 potential security risks in this container, and
 [None](https://console.cloud.google.com/gcr/images/cloud-foundation-cicd/global/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011/details?tab=vulnz)
 is reported.

--- a/examples/tfengine/generated/folder_foundation/cicd/README.md
+++ b/examples/tfengine/generated/folder_foundation/cicd/README.md
@@ -65,6 +65,11 @@ validate and deploy Terraform configs. If you would like to use a different
 container for production deployment, you can modify the Cloud Build YAML files
 in [./configs](./configs) directory to point to your container.
 
+We leverage Cloud Container Registry's Vulnerability scanning feature to detect
+potential security risks in this container, and
+[None](https://console.cloud.google.com/gcr/images/cloud-foundation-cicd/global/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011/details?tab=vulnz)
+is reported.
+
 ## Features
 
 ### Event-triggered builds

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/tf-apply.yaml
@@ -21,18 +21,18 @@ substitutions:
     _MANAGED_DIRS: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/import.sh", "-d", "${_MANAGED_DIRS}"]
     dir: "${_TERRAFORM_ROOT}"
     id: Import existing projects
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init", "-a", "plan", "-a", "apply -auto-approve"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/tf-plan.yaml
@@ -21,19 +21,19 @@ substitutions:
     _MANAGED_DIRS: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -lock=false", "-a", "plan -lock=false -out=plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"
     id: Speculative plan
 
   # Check for delete operations as an FYI, it won't fail the build.
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/tf-deletion-check.sh", "./cicd/configs/tf-deletion-allowlist.txt"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/tf-validate.yaml
@@ -21,18 +21,18 @@ substitutions:
     _MANAGED_DIRS: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["fmt", "-recursive", "-check"]
     dir: "${_TERRAFORM_ROOT}"
     id: Terraform configs format check
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -backend=false", "-a", "validate"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/multi_envs/cicd/README.md
+++ b/examples/tfengine/generated/multi_envs/cicd/README.md
@@ -65,7 +65,7 @@ validate and deploy Terraform configs. If you would like to use a different
 container for production deployment, you can modify the Cloud Build YAML files
 in [./configs](./configs) directory to point to your container.
 
-We leverage Cloud Container Registry's Vulnerability scanning feature to detect
+We leverage Google Container Registry's Vulnerability scanning feature to detect
 potential security risks in this container, and
 [None](https://console.cloud.google.com/gcr/images/cloud-foundation-cicd/global/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011/details?tab=vulnz)
 is reported.

--- a/examples/tfengine/generated/multi_envs/cicd/README.md
+++ b/examples/tfengine/generated/multi_envs/cicd/README.md
@@ -65,6 +65,11 @@ validate and deploy Terraform configs. If you would like to use a different
 container for production deployment, you can modify the Cloud Build YAML files
 in [./configs](./configs) directory to point to your container.
 
+We leverage Cloud Container Registry's Vulnerability scanning feature to detect
+potential security risks in this container, and
+[None](https://console.cloud.google.com/gcr/images/cloud-foundation-cicd/global/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011/details?tab=vulnz)
+is reported.
+
 ## Features
 
 ### Event-triggered builds

--- a/examples/tfengine/generated/multi_envs/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/multi_envs/cicd/configs/tf-apply.yaml
@@ -21,18 +21,18 @@ substitutions:
     _MANAGED_DIRS: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/import.sh", "-d", "${_MANAGED_DIRS}"]
     dir: "${_TERRAFORM_ROOT}"
     id: Import existing projects
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init", "-a", "plan", "-a", "apply -auto-approve"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/multi_envs/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/multi_envs/cicd/configs/tf-plan.yaml
@@ -21,19 +21,19 @@ substitutions:
     _MANAGED_DIRS: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -lock=false", "-a", "plan -lock=false -out=plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"
     id: Speculative plan
 
   # Check for delete operations as an FYI, it won't fail the build.
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/tf-deletion-check.sh", "./cicd/configs/tf-deletion-allowlist.txt"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/multi_envs/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/multi_envs/cicd/configs/tf-validate.yaml
@@ -21,18 +21,18 @@ substitutions:
     _MANAGED_DIRS: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["fmt", "-recursive", "-check"]
     dir: "${_TERRAFORM_ROOT}"
     id: Terraform configs format check
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -backend=false", "-a", "validate"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/org_foundation/cicd/README.md
+++ b/examples/tfengine/generated/org_foundation/cicd/README.md
@@ -65,7 +65,7 @@ validate and deploy Terraform configs. If you would like to use a different
 container for production deployment, you can modify the Cloud Build YAML files
 in [./configs](./configs) directory to point to your container.
 
-We leverage Cloud Container Registry's Vulnerability scanning feature to detect
+We leverage Google Container Registry's Vulnerability scanning feature to detect
 potential security risks in this container, and
 [None](https://console.cloud.google.com/gcr/images/cloud-foundation-cicd/global/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011/details?tab=vulnz)
 is reported.

--- a/examples/tfengine/generated/org_foundation/cicd/README.md
+++ b/examples/tfengine/generated/org_foundation/cicd/README.md
@@ -65,6 +65,11 @@ validate and deploy Terraform configs. If you would like to use a different
 container for production deployment, you can modify the Cloud Build YAML files
 in [./configs](./configs) directory to point to your container.
 
+We leverage Cloud Container Registry's Vulnerability scanning feature to detect
+potential security risks in this container, and
+[None](https://console.cloud.google.com/gcr/images/cloud-foundation-cicd/global/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011/details?tab=vulnz)
+is reported.
+
 ## Features
 
 ### Event-triggered builds

--- a/examples/tfengine/generated/org_foundation/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/tf-apply.yaml
@@ -21,18 +21,18 @@ substitutions:
     _MANAGED_DIRS: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/import.sh", "-d", "${_MANAGED_DIRS}"]
     dir: "${_TERRAFORM_ROOT}"
     id: Import existing projects
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init", "-a", "plan", "-a", "apply -auto-approve"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/org_foundation/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/tf-plan.yaml
@@ -21,19 +21,19 @@ substitutions:
     _MANAGED_DIRS: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -lock=false", "-a", "plan -lock=false -out=plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"
     id: Speculative plan
 
   # Check for delete operations as an FYI, it won't fail the build.
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/tf-deletion-check.sh", "./cicd/configs/tf-deletion-allowlist.txt"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/org_foundation/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/tf-validate.yaml
@@ -21,18 +21,18 @@ substitutions:
     _MANAGED_DIRS: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["fmt", "-recursive", "-check"]
     dir: "${_TERRAFORM_ROOT}"
     id: Terraform configs format check
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -backend=false", "-a", "validate"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/team/cicd/README.md
+++ b/examples/tfengine/generated/team/cicd/README.md
@@ -65,7 +65,7 @@ validate and deploy Terraform configs. If you would like to use a different
 container for production deployment, you can modify the Cloud Build YAML files
 in [./configs](./configs) directory to point to your container.
 
-We leverage Cloud Container Registry's Vulnerability scanning feature to detect
+We leverage Google Container Registry's Vulnerability scanning feature to detect
 potential security risks in this container, and
 [None](https://console.cloud.google.com/gcr/images/cloud-foundation-cicd/global/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011/details?tab=vulnz)
 is reported.

--- a/examples/tfengine/generated/team/cicd/README.md
+++ b/examples/tfengine/generated/team/cicd/README.md
@@ -65,6 +65,11 @@ validate and deploy Terraform configs. If you would like to use a different
 container for production deployment, you can modify the Cloud Build YAML files
 in [./configs](./configs) directory to point to your container.
 
+We leverage Cloud Container Registry's Vulnerability scanning feature to detect
+potential security risks in this container, and
+[None](https://console.cloud.google.com/gcr/images/cloud-foundation-cicd/global/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011/details?tab=vulnz)
+is reported.
+
 ## Features
 
 ### Event-triggered builds

--- a/examples/tfengine/generated/team/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/team/cicd/configs/tf-apply.yaml
@@ -21,18 +21,18 @@ substitutions:
     _MANAGED_DIRS: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/import.sh", "-d", "${_MANAGED_DIRS}"]
     dir: "${_TERRAFORM_ROOT}"
     id: Import existing projects
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init", "-a", "plan", "-a", "apply -auto-approve"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/team/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/team/cicd/configs/tf-plan.yaml
@@ -21,19 +21,19 @@ substitutions:
     _MANAGED_DIRS: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -lock=false", "-a", "plan -lock=false -out=plan.tfplan"]
     dir: "${_TERRAFORM_ROOT}"
     id: Speculative plan
 
   # Check for delete operations as an FYI, it won't fail the build.
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/tf-deletion-check.sh", "./cicd/configs/tf-deletion-allowlist.txt"]
     dir: "${_TERRAFORM_ROOT}"

--- a/examples/tfengine/generated/team/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/team/cicd/configs/tf-validate.yaml
@@ -21,18 +21,18 @@ substitutions:
     _MANAGED_DIRS: ""
 
 steps:
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["version"]
     id: Terraform version
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: terraform
     args: ["fmt", "-recursive", "-check"]
     dir: "${_TERRAFORM_ROOT}"
     id: Terraform configs format check
 
-  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"
+  - name: "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"
     entrypoint: bash
     args: ["./cicd/configs/run.sh", "-d", "${_MANAGED_DIRS}", "-a", "init -backend=false", "-a", "validate"]
     dir: "${_TERRAFORM_ROOT}"

--- a/templates/tfengine/components/cicd/README.md
+++ b/templates/tfengine/components/cicd/README.md
@@ -65,7 +65,7 @@ validate and deploy Terraform configs. If you would like to use a different
 container for production deployment, you can modify the Cloud Build YAML files
 in [./configs](./configs) directory to point to your container.
 
-We leverage Cloud Container Registry's Vulnerability scanning feature to detect
+We leverage Google Container Registry's Vulnerability scanning feature to detect
 potential security risks in this container, and
 [None](https://console.cloud.google.com/gcr/images/cloud-foundation-cicd/global/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011/details?tab=vulnz)
 is reported.

--- a/templates/tfengine/components/cicd/README.md
+++ b/templates/tfengine/components/cicd/README.md
@@ -65,6 +65,11 @@ validate and deploy Terraform configs. If you would like to use a different
 container for production deployment, you can modify the Cloud Build YAML files
 in [./configs](./configs) directory to point to your container.
 
+We leverage Cloud Container Registry's Vulnerability scanning feature to detect
+potential security risks in this container, and
+[None](https://console.cloud.google.com/gcr/images/cloud-foundation-cicd/global/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011/details?tab=vulnz)
+is reported.
+
 ## Features
 
 ### Event-triggered builds

--- a/templates/tfengine/components/cicd/configs/tf-apply.yaml
+++ b/templates/tfengine/components/cicd/configs/tf-apply.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Note: Terraform version used in the automation is 0.14.8.
-{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"}}
+{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"}}
 
 timeout: 21600s
 

--- a/templates/tfengine/components/cicd/configs/tf-plan.yaml
+++ b/templates/tfengine/components/cicd/configs/tf-plan.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Note: Terraform version used in the automation is 0.14.8.
-{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"}}
+{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"}}
 
 timeout: 1200s
 

--- a/templates/tfengine/components/cicd/configs/tf-validate.yaml
+++ b/templates/tfengine/components/cicd/configs/tf-validate.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Note: Terraform version used in the automation is 0.14.8.
-{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:3a3b2cf77a1096c56bd76c3466d7f2a584132396097944a7725e996fce76d5cc"}}
+{{- $cft := "gcr.io/cloud-foundation-cicd/cft/developer-tools-light@sha256:d881ce4ff2a73fa0877dd357af798a431a601b2ccfe5a140837bcb883cd3f011"}}
 
 timeout: 600s
 


### PR DESCRIPTION
The container base is switched in
https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/pull/943.
The original one has 72 vulnerabilities reported by GCR. The new one has
zero.