### PR TITLE
chore: Update license to 2021

### DIFF
--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/release-latest-binaries.yaml
+++ b/.github/workflows/release-latest-binaries.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/release-policies.yaml
+++ b/.github/workflows/release-policies.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/release-templates.yaml
+++ b/.github/workflows/release-templates.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/build-binaries.sh
+++ b/build/build-binaries.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/build-include.sh
+++ b/build/build-include.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/build-policies.sh
+++ b/build/build-policies.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/build-release.sh
+++ b/build/build-release.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/build-templates.sh
+++ b/build/build-templates.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/gen_check.sh
+++ b/build/gen_check.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/go_check.sh
+++ b/build/go_check.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/install-hub.sh
+++ b/build/install-hub.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/license_check.sh
+++ b/build/license_check.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/md_check.sh
+++ b/build/md_check.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/presubmit_int.yaml
+++ b/build/presubmit_int.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/presubmit_unit.yaml
+++ b/build/presubmit_unit.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmd/policygen/main.go
+++ b/cmd/policygen/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/tfengine/main.go
+++ b/cmd/tfengine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/tfimport/main.go
+++ b/cmd/tfimport/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/policygen/config.hcl
+++ b/examples/policygen/config.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/config.yaml
+++ b/examples/policygen/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_appengine_appviewer.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_appengine_appviewer.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_bigquery_metadataviewer.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_bigquery_metadataviewer.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_browser.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_browser.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_cloudasset_viewer.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_cloudasset_viewer.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_cloudsql_viewer.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_cloudsql_viewer.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_compute_networkviewer.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_compute_networkviewer.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_custom_osloginprojectget_6afd.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_custom_osloginprojectget_6afd.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_iam_securityreviewer.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_iam_securityreviewer.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_orgpolicy_policyviewer.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_orgpolicy_policyviewer.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_owner.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_owner.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_servicemanagement_quotaviewer.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_servicemanagement_quotaviewer.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_serviceusage_serviceusageconsumer.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_bindings_serviceusage_serviceusageconsumer.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_roles.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/organization_12345678/iam_allow_roles.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/overall/bigquery_allow_locations.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/overall/bigquery_allow_locations.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/overall/dataproc_allow_locations.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/overall/dataproc_allow_locations.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/overall/iam_allow_domains.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/overall/iam_allow_domains.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/overall/iam_deny_public_access.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/overall/iam_deny_public_access.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/overall/iam_enable_audit_logs.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/overall/iam_enable_audit_logs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/overall/network_enable_firewall_logs.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/overall/network_enable_firewall_logs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/overall/network_enable_flow_logs.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/overall/network_enable_flow_logs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/overall/service_allow_apis.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/overall/service_allow_apis.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/overall/sql_allow_locations.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/overall/sql_allow_locations.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/overall/sql_deny_public_access.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/overall/sql_deny_public_access.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/overall/storage_allow_locations.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/overall/storage_allow_locations.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/policygen/generated/forseti_policies/policies/constraints/overall/storage_allow_uniform_bucket_access_only.yaml
+++ b/examples/policygen/generated/forseti_policies/policies/constraints/overall/storage_allow_uniform_bucket_access_only.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/devops.hcl
+++ b/examples/tfengine/devops.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/folder_foundation.hcl
+++ b/examples/tfengine/folder_foundation.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/devops/cicd/configs/import.sh
+++ b/examples/tfengine/generated/devops/cicd/configs/import.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/devops/cicd/configs/run.sh
+++ b/examples/tfengine/generated/devops/cicd/configs/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/devops/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/devops/cicd/configs/tf-apply.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/devops/cicd/configs/tf-deletion-check.sh
+++ b/examples/tfengine/generated/devops/cicd/configs/tf-deletion-check.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/devops/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/devops/cicd/configs/tf-plan.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/devops/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/devops/cicd/configs/tf-validate.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/devops/cicd/main.tf
+++ b/examples/tfengine/generated/devops/cicd/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/devops/cicd/terraform.tfvars
+++ b/examples/tfengine/generated/devops/cicd/terraform.tfvars
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/devops/cicd/triggers.tf
+++ b/examples/tfengine/generated/devops/cicd/triggers.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/devops/cicd/variables.tf
+++ b/examples/tfengine/generated/devops/cicd/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/devops/devops/main.tf
+++ b/examples/tfengine/generated/devops/devops/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/devops/groups/main.tf
+++ b/examples/tfengine/generated/devops/groups/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/audit/main.tf
+++ b/examples/tfengine/generated/folder_foundation/audit/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/audit/terraform.tfvars
+++ b/examples/tfengine/generated/folder_foundation/audit/terraform.tfvars
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/audit/variables.tf
+++ b/examples/tfengine/generated/folder_foundation/audit/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/import.sh
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/import.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/run.sh
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/tf-apply.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/tf-deletion-check.sh
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/tf-deletion-check.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/tf-plan.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/tf-validate.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/cicd/main.tf
+++ b/examples/tfengine/generated/folder_foundation/cicd/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/cicd/terraform.tfvars
+++ b/examples/tfengine/generated/folder_foundation/cicd/terraform.tfvars
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/cicd/triggers.tf
+++ b/examples/tfengine/generated/folder_foundation/cicd/triggers.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/cicd/variables.tf
+++ b/examples/tfengine/generated/folder_foundation/cicd/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/devops/main.tf
+++ b/examples/tfengine/generated/folder_foundation/devops/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/example-prod-networks/main.tf
+++ b/examples/tfengine/generated/folder_foundation/example-prod-networks/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/folders/main.tf
+++ b/examples/tfengine/generated/folder_foundation/folders/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/folders/outputs.tf
+++ b/examples/tfengine/generated/folder_foundation/folders/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/groups/main.tf
+++ b/examples/tfengine/generated/folder_foundation/groups/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/folder_foundation/monitor/main.tf
+++ b/examples/tfengine/generated/folder_foundation/monitor/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/audit/main.tf
+++ b/examples/tfengine/generated/multi_envs/audit/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/audit/terraform.tfvars
+++ b/examples/tfengine/generated/multi_envs/audit/terraform.tfvars
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/audit/variables.tf
+++ b/examples/tfengine/generated/multi_envs/audit/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/cicd/configs/import.sh
+++ b/examples/tfengine/generated/multi_envs/cicd/configs/import.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/cicd/configs/run.sh
+++ b/examples/tfengine/generated/multi_envs/cicd/configs/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/multi_envs/cicd/configs/tf-apply.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/cicd/configs/tf-deletion-check.sh
+++ b/examples/tfengine/generated/multi_envs/cicd/configs/tf-deletion-check.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/multi_envs/cicd/configs/tf-plan.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/multi_envs/cicd/configs/tf-validate.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/cicd/main.tf
+++ b/examples/tfengine/generated/multi_envs/cicd/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/cicd/terraform.tfvars
+++ b/examples/tfengine/generated/multi_envs/cicd/terraform.tfvars
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/cicd/triggers.tf
+++ b/examples/tfengine/generated/multi_envs/cicd/triggers.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/cicd/variables.tf
+++ b/examples/tfengine/generated/multi_envs/cicd/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/dev/data/main.tf
+++ b/examples/tfengine/generated/multi_envs/dev/data/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/devops/main.tf
+++ b/examples/tfengine/generated/multi_envs/devops/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/folders/main.tf
+++ b/examples/tfengine/generated/multi_envs/folders/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/folders/outputs.tf
+++ b/examples/tfengine/generated/multi_envs/folders/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/groups/main.tf
+++ b/examples/tfengine/generated/multi_envs/groups/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/multi_envs/prod/data/main.tf
+++ b/examples/tfengine/generated/multi_envs/prod/data/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/audit/main.tf
+++ b/examples/tfengine/generated/org_foundation/audit/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/audit/terraform.tfvars
+++ b/examples/tfengine/generated/org_foundation/audit/terraform.tfvars
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/audit/variables.tf
+++ b/examples/tfengine/generated/org_foundation/audit/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/cicd/configs/import.sh
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/import.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/cicd/configs/run.sh
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/tf-apply.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/cicd/configs/tf-deletion-check.sh
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/tf-deletion-check.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/tf-plan.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/tf-validate.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/cicd/main.tf
+++ b/examples/tfengine/generated/org_foundation/cicd/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/cicd/terraform.tfvars
+++ b/examples/tfengine/generated/org_foundation/cicd/terraform.tfvars
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/cicd/triggers.tf
+++ b/examples/tfengine/generated/org_foundation/cicd/triggers.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/cicd/variables.tf
+++ b/examples/tfengine/generated/org_foundation/cicd/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/devops/main.tf
+++ b/examples/tfengine/generated/org_foundation/devops/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/example-prod-networks/main.tf
+++ b/examples/tfengine/generated/org_foundation/example-prod-networks/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/folders/main.tf
+++ b/examples/tfengine/generated/org_foundation/folders/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/folders/outputs.tf
+++ b/examples/tfengine/generated/org_foundation/folders/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/groups/main.tf
+++ b/examples/tfengine/generated/org_foundation/groups/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/monitor/main.tf
+++ b/examples/tfengine/generated/org_foundation/monitor/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/org_policies/main.tf
+++ b/examples/tfengine/generated/org_foundation/org_policies/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/org_policies/terraform.tfvars
+++ b/examples/tfengine/generated/org_foundation/org_policies/terraform.tfvars
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_foundation/org_policies/variables.tf
+++ b/examples/tfengine/generated/org_foundation/org_policies/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_policies/org_policies/main.tf
+++ b/examples/tfengine/generated/org_policies/org_policies/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_policies/org_policies/terraform.tfvars
+++ b/examples/tfengine/generated/org_policies/org_policies/terraform.tfvars
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/org_policies/org_policies/variables.tf
+++ b/examples/tfengine/generated/org_policies/org_policies/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/resources_only/resources/main.tf
+++ b/examples/tfengine/generated/resources_only/resources/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/cicd/configs/import.sh
+++ b/examples/tfengine/generated/team/cicd/configs/import.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/cicd/configs/run.sh
+++ b/examples/tfengine/generated/team/cicd/configs/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/cicd/configs/tf-apply.yaml
+++ b/examples/tfengine/generated/team/cicd/configs/tf-apply.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/cicd/configs/tf-deletion-check.sh
+++ b/examples/tfengine/generated/team/cicd/configs/tf-deletion-check.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/cicd/configs/tf-plan.yaml
+++ b/examples/tfengine/generated/team/cicd/configs/tf-plan.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/cicd/configs/tf-validate.yaml
+++ b/examples/tfengine/generated/team/cicd/configs/tf-validate.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/cicd/main.tf
+++ b/examples/tfengine/generated/team/cicd/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/cicd/terraform.tfvars
+++ b/examples/tfengine/generated/team/cicd/terraform.tfvars
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/cicd/triggers.tf
+++ b/examples/tfengine/generated/team/cicd/triggers.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/cicd/variables.tf
+++ b/examples/tfengine/generated/team/cicd/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/devops/main.tf
+++ b/examples/tfengine/generated/team/devops/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/groups/main.tf
+++ b/examples/tfengine/generated/team/groups/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/kubernetes/main.tf
+++ b/examples/tfengine/generated/team/kubernetes/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/project_apps/main.tf
+++ b/examples/tfengine/generated/team/project_apps/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/project_data/main.tf
+++ b/examples/tfengine/generated/team/project_data/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/project_networks/main.tf
+++ b/examples/tfengine/generated/team/project_networks/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/generated/team/project_secrets/main.tf
+++ b/examples/tfengine/generated/team/project_secrets/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/modules/foundation.hcl
+++ b/examples/tfengine/modules/foundation.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/modules/root.hcl
+++ b/examples/tfengine/modules/root.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/modules/team.hcl
+++ b/examples/tfengine/modules/team.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/multi_envs.hcl
+++ b/examples/tfengine/multi_envs.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/org_foundation.hcl
+++ b/examples/tfengine/org_foundation.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/org_policies.hcl
+++ b/examples/tfengine/org_policies.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/resources_only.hcl
+++ b/examples/tfengine/resources_only.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/tfengine/team.hcl
+++ b/examples/tfengine/team.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/hcl/hcl.go
+++ b/internal/hcl/hcl.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/hcl/hcl_test.go
+++ b/internal/hcl/hcl_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/jsonschema/validate.go
+++ b/internal/jsonschema/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/licenseutil/licenseutil.go
+++ b/internal/licenseutil/licenseutil.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import (
 	"strings"
 )
 
-var license = []byte(`# Copyright 2020 Google LLC
+var license = []byte(`# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ func writeLicense(path string, fmode os.FileMode) error {
 		return err
 	}
 
-	if bytes.Contains(b, []byte("Copyright 2020 Google LLC")) {
+	if bytes.Contains(b, []byte("Copyright 2021 Google LLC")) {
 		return nil
 	}
 

--- a/internal/policygen/iam.go
+++ b/internal/policygen/iam.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/policygen/iam_test.go
+++ b/internal/policygen/iam_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/policygen/load.go
+++ b/internal/policygen/load.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/policygen/policygen.go
+++ b/internal/policygen/policygen.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/policygen/policygen_test.go
+++ b/internal/policygen/policygen_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/policygen/schema.go
+++ b/internal/policygen/schema.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/template/funcmap.go
+++ b/internal/template/funcmap.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC.
+// Copyright 2021 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC.
+// Copyright 2021 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC.
+// Copyright 2021 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/terraform/json.go
+++ b/internal/terraform/json.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/terraform/json_test.go
+++ b/internal/terraform/json_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/terraform/state.go
+++ b/internal/terraform/state.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/terraform/state_test.go
+++ b/internal/terraform/state_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tfengine/config.go
+++ b/internal/tfengine/config.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tfengine/schema.go
+++ b/internal/tfengine/schema.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tfengine/tfengine.go
+++ b/internal/tfengine/tfengine.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tfengine/tfengine_test.go
+++ b/internal/tfengine/tfengine_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tfimport/importer/google_billing_budget.go
+++ b/internal/tfimport/importer/google_billing_budget.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tfimport/importer/google_compute_network_peering.go
+++ b/internal/tfimport/importer/google_compute_network_peering.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tfimport/importer/google_resource_manager_lien.go
+++ b/internal/tfimport/importer/google_resource_manager_lien.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tfimport/importer/google_service_networking_connection.go
+++ b/internal/tfimport/importer/google_service_networking_connection.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tfimport/importer/google_sql_user.go
+++ b/internal/tfimport/importer/google_sql_user.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tfimport/importer/random_id.go
+++ b/internal/tfimport/importer/random_id.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC.
+ * Copyright 2021 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/tfimport/importer/random_integer.go
+++ b/internal/tfimport/importer/random_integer.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC.
+ * Copyright 2021 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/tfimport/importer/resources.go
+++ b/internal/tfimport/importer/resources.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tfimport/importer/resources_test.go
+++ b/internal/tfimport/importer/resources_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tfimport/importer/simple_importer.go
+++ b/internal/tfimport/importer/simple_importer.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tfimport/tfimport.go
+++ b/internal/tfimport/tfimport.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/tfimport/tfimport_test.go
+++ b/internal/tfimport/tfimport_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC.
+// Copyright 2021 Google LLC.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scripts/check_importer_supports_engine/main.go
+++ b/scripts/check_importer_supports_engine/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scripts/generate_schema_docs/main.go
+++ b/scripts/generate_schema_docs/main.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scripts/generate_schema_docs/schema.go
+++ b/scripts/generate_schema_docs/schema.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scripts/generate_schema_docs/template.go
+++ b/scripts/generate_schema_docs/template.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scripts/links_check.sh
+++ b/scripts/links_check.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/regen.sh
+++ b/scripts/regen.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/policygen/forseti/overall/bigquery_allow_locations.yaml
+++ b/templates/policygen/forseti/overall/bigquery_allow_locations.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/policygen/forseti/overall/dataproc_allow_locations.yaml
+++ b/templates/policygen/forseti/overall/dataproc_allow_locations.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/policygen/forseti/overall/iam_allow_domains.yaml
+++ b/templates/policygen/forseti/overall/iam_allow_domains.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/policygen/forseti/overall/iam_deny_public_access.yaml
+++ b/templates/policygen/forseti/overall/iam_deny_public_access.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/policygen/forseti/overall/iam_enable_audit_logs.yaml
+++ b/templates/policygen/forseti/overall/iam_enable_audit_logs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/policygen/forseti/overall/network_enable_firewall_logs.yaml
+++ b/templates/policygen/forseti/overall/network_enable_firewall_logs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/policygen/forseti/overall/network_enable_flow_logs.yaml
+++ b/templates/policygen/forseti/overall/network_enable_flow_logs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/policygen/forseti/overall/service_allow_apis.yaml
+++ b/templates/policygen/forseti/overall/service_allow_apis.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/policygen/forseti/overall/sql_allow_locations.yaml
+++ b/templates/policygen/forseti/overall/sql_allow_locations.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/policygen/forseti/overall/sql_deny_public_access.yaml
+++ b/templates/policygen/forseti/overall/sql_deny_public_access.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/policygen/forseti/overall/storage_allow_locations.yaml
+++ b/templates/policygen/forseti/overall/storage_allow_locations.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/policygen/forseti/overall/storage_allow_uniform_bucket_access_only.yaml
+++ b/templates/policygen/forseti/overall/storage_allow_uniform_bucket_access_only.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/policygen/forseti/tf_based/iam_allow_bindings.yaml
+++ b/templates/policygen/forseti/tf_based/iam_allow_bindings.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/policygen/forseti/tf_based/iam_allow_roles.yaml
+++ b/templates/policygen/forseti/tf_based/iam_allow_roles.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/audit/main.tf
+++ b/templates/tfengine/components/audit/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/audit/terraform.tfvars
+++ b/templates/tfengine/components/audit/terraform.tfvars
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/audit/variables.tf
+++ b/templates/tfengine/components/audit/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/cicd/configs/import.sh
+++ b/templates/tfengine/components/cicd/configs/import.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/cicd/configs/run.sh
+++ b/templates/tfengine/components/cicd/configs/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/cicd/configs/tf-apply.yaml
+++ b/templates/tfengine/components/cicd/configs/tf-apply.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/cicd/configs/tf-deletion-check.sh
+++ b/templates/tfengine/components/cicd/configs/tf-deletion-check.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/cicd/configs/tf-plan.yaml
+++ b/templates/tfengine/components/cicd/configs/tf-plan.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/cicd/configs/tf-validate.yaml
+++ b/templates/tfengine/components/cicd/configs/tf-validate.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/cicd/main.tf
+++ b/templates/tfengine/components/cicd/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/cicd/terraform.tfvars
+++ b/templates/tfengine/components/cicd/terraform.tfvars
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/cicd/triggers.tf
+++ b/templates/tfengine/components/cicd/triggers.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/cicd/variables.tf
+++ b/templates/tfengine/components/cicd/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/devops/main.tf
+++ b/templates/tfengine/components/devops/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/folders/main.tf
+++ b/templates/tfengine/components/folders/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/folders/outputs.tf
+++ b/templates/tfengine/components/folders/outputs.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/monitor/forseti/main.tf
+++ b/templates/tfengine/components/monitor/forseti/main.tf
@@ -1,4 +1,4 @@
-{{/* Copyright 2020 Google LLC
+{{/* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/org_policies/main.tf
+++ b/templates/tfengine/components/org_policies/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/org_policies/terraform.tfvars
+++ b/templates/tfengine/components/org_policies/terraform.tfvars
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/org_policies/variables.tf
+++ b/templates/tfengine/components/org_policies/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/project/main.tf
+++ b/templates/tfengine/components/project/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/templates/tfengine/components/resources/bastion_hosts/main.tf
+++ b/templates/tfengine/components/resources/bastion_hosts/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/resources/bigquery_datasets/main.tf
+++ b/templates/tfengine/components/resources/bigquery_datasets/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/resources/binary_authorization/main.tf
+++ b/templates/tfengine/components/resources/binary_authorization/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/resources/cloud_sql_instances/main.tf
+++ b/templates/tfengine/components/resources/cloud_sql_instances/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/resources/compute_instance_templates/main.tf
+++ b/templates/tfengine/components/resources/compute_instance_templates/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/resources/compute_networks/main.tf
+++ b/templates/tfengine/components/resources/compute_networks/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/resources/compute_routers/main.tf
+++ b/templates/tfengine/components/resources/compute_routers/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/resources/dns_zones/main.tf
+++ b/templates/tfengine/components/resources/dns_zones/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/resources/gke_clusters/main.tf
+++ b/templates/tfengine/components/resources/gke_clusters/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/resources/groups/main.tf
+++ b/templates/tfengine/components/resources/groups/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/resources/healthcare_datasets/main.tf
+++ b/templates/tfengine/components/resources/healthcare_datasets/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/resources/iam_members/main.tf
+++ b/templates/tfengine/components/resources/iam_members/main.tf
@@ -1,4 +1,4 @@
-{{/* Copyright 2020 Google LLC
+{{/* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/resources/pubsub_topics/main.tf
+++ b/templates/tfengine/components/resources/pubsub_topics/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/resources/secrets/main.tf
+++ b/templates/tfengine/components/resources/secrets/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/resources/service_accounts/main.tf
+++ b/templates/tfengine/components/resources/service_accounts/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/resources/storage_buckets/main.tf
+++ b/templates/tfengine/components/resources/storage_buckets/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/terraform/main/main.tf
+++ b/templates/tfengine/components/terraform/main/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/terraform/outputs/outputs.tf
+++ b/templates/tfengine/components/terraform/outputs/outputs.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/terraform/states/main.tf
+++ b/templates/tfengine/components/terraform/states/main.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/terraform/variables/terraform.tfvars
+++ b/templates/tfengine/components/terraform/variables/terraform.tfvars
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/components/terraform/variables/variables.tf
+++ b/templates/tfengine/components/terraform/variables/variables.tf
@@ -1,4 +1,4 @@
-{{- /* Copyright 2020 Google LLC
+{{- /* Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/templates/tfengine/recipes/audit.hcl
+++ b/templates/tfengine/recipes/audit.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/recipes/cicd.hcl
+++ b/templates/tfengine/recipes/cicd.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/recipes/deployment.hcl
+++ b/templates/tfengine/recipes/deployment.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/recipes/devops.hcl
+++ b/templates/tfengine/recipes/devops.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/recipes/folders.hcl
+++ b/templates/tfengine/recipes/folders.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/recipes/monitor.hcl
+++ b/templates/tfengine/recipes/monitor.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/recipes/org_policies.hcl
+++ b/templates/tfengine/recipes/org_policies.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/recipes/project.hcl
+++ b/templates/tfengine/recipes/project.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/tfengine/recipes/resources.hcl
+++ b/templates/tfengine/recipes/resources.hcl
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/policygen/integration_test.sh
+++ b/tests/policygen/integration_test.sh
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/tfengine/integration_test.go
+++ b/tests/tfengine/integration_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Changes

- Update `internal/licenseutil/licenseutil.go` to have the 2021 license
- Update another internal files with the copyright notice to 2021

Note: Some files are still with licenses from < 2020, those come from [here](https://github.com/forseti-security/policy-library/tree/master/policies/templates), and we don't have direct control over them.