### PR TITLE
Update log-export module.

### DIFF
--- a/examples/tfengine/generated/folder_foundation/audit/main.tf
+++ b/examples/tfengine/generated/folder_foundation/audit/main.tf
@@ -70,7 +70,7 @@ resource "google_folder_iam_audit_config" "config" {
 
 module "bigquery_export" {
   source  = "terraform-google-modules/log-export/google"
-  version = "~> 5.2.0"
+  version = "~> 6.0.1"
 
   log_sink_name          = "example-bigquery-audit-logs-sink"
   destination_uri        = module.bigquery_destination.destination_uri
@@ -83,7 +83,7 @@ module "bigquery_export" {
 
 module "bigquery_destination" {
   source  = "terraform-google-modules/log-export/google//modules/bigquery"
-  version = "~> 5.2.0"
+  version = "~> 6.0.1"
 
   dataset_name             = "1yr_folder_audit_logs"
   project_id               = module.project.project_id
@@ -94,7 +94,7 @@ module "bigquery_destination" {
 
 module "storage_export" {
   source  = "terraform-google-modules/log-export/google"
-  version = "~> 5.2.0"
+  version = "~> 6.0.1"
 
   log_sink_name          = "example-storage-audit-logs-sink"
   destination_uri        = module.storage_destination.destination_uri
@@ -110,7 +110,7 @@ module "storage_export" {
 // and set the actual expiry to be greater than this amount (7 years).
 module "storage_destination" {
   source  = "terraform-google-modules/log-export/google//modules/storage"
-  version = "~> 5.2.0"
+  version = "~> 6.0.1"
 
   storage_bucket_name      = "7yr-folder-audit-logs"
   project_id               = module.project.project_id

--- a/examples/tfengine/generated/multi_envs/audit/main.tf
+++ b/examples/tfengine/generated/multi_envs/audit/main.tf
@@ -70,7 +70,7 @@ resource "google_folder_iam_audit_config" "config" {
 
 module "bigquery_export" {
   source  = "terraform-google-modules/log-export/google"
-  version = "~> 5.2.0"
+  version = "~> 6.0.1"
 
   log_sink_name          = "example-bigquery-audit-logs-sink"
   destination_uri        = module.bigquery_destination.destination_uri
@@ -83,7 +83,7 @@ module "bigquery_export" {
 
 module "bigquery_destination" {
   source  = "terraform-google-modules/log-export/google//modules/bigquery"
-  version = "~> 5.2.0"
+  version = "~> 6.0.1"
 
   dataset_name             = "1yr_folder_audit_logs"
   project_id               = module.project.project_id
@@ -94,7 +94,7 @@ module "bigquery_destination" {
 
 module "storage_export" {
   source  = "terraform-google-modules/log-export/google"
-  version = "~> 5.2.0"
+  version = "~> 6.0.1"
 
   log_sink_name          = "example-storage-audit-logs-sink"
   destination_uri        = module.storage_destination.destination_uri
@@ -110,7 +110,7 @@ module "storage_export" {
 // and set the actual expiry to be greater than this amount (7 years).
 module "storage_destination" {
   source  = "terraform-google-modules/log-export/google//modules/storage"
-  version = "~> 5.2.0"
+  version = "~> 6.0.1"
 
   storage_bucket_name      = "7yr-folder-audit-logs"
   project_id               = module.project.project_id

--- a/examples/tfengine/generated/org_foundation/audit/main.tf
+++ b/examples/tfengine/generated/org_foundation/audit/main.tf
@@ -69,7 +69,7 @@ resource "google_organization_iam_audit_config" "config" {
 
 module "bigquery_export" {
   source  = "terraform-google-modules/log-export/google"
-  version = "~> 5.2.0"
+  version = "~> 6.0.1"
 
   log_sink_name          = "bigquery-audit-logs-sink"
   destination_uri        = module.bigquery_destination.destination_uri
@@ -82,7 +82,7 @@ module "bigquery_export" {
 
 module "bigquery_destination" {
   source  = "terraform-google-modules/log-export/google//modules/bigquery"
-  version = "~> 5.2.0"
+  version = "~> 6.0.1"
 
   dataset_name             = "1yr_org_audit_logs"
   project_id               = module.project.project_id
@@ -93,7 +93,7 @@ module "bigquery_destination" {
 
 module "storage_export" {
   source  = "terraform-google-modules/log-export/google"
-  version = "~> 5.2.0"
+  version = "~> 6.0.1"
 
   log_sink_name          = "storage-audit-logs-sink"
   destination_uri        = module.storage_destination.destination_uri
@@ -109,7 +109,7 @@ module "storage_export" {
 // and set the actual expiry to be greater than this amount (7 years).
 module "storage_destination" {
   source  = "terraform-google-modules/log-export/google//modules/storage"
-  version = "~> 5.2.0"
+  version = "~> 6.0.1"
 
   storage_bucket_name      = "7yr-org-audit-logs"
   project_id               = module.project.project_id

--- a/templates/tfengine/components/audit/main.tf
+++ b/templates/tfengine/components/audit/main.tf
@@ -42,7 +42,7 @@ resource "google_{{.parent_type}}_iam_audit_config" "config" {
 
 module "bigquery_export" {
   source  = "terraform-google-modules/log-export/google"
-  version = "~> 5.2.0"
+  version = "~> 6.0.1"
 
   log_sink_name          = "{{get .logs_bigquery_dataset "sink_name" "bigquery-audit-logs-sink"}}"
   destination_uri        = "${module.bigquery_destination.destination_uri}"
@@ -55,7 +55,7 @@ module "bigquery_export" {
 
 module "bigquery_destination" {
   source  = "terraform-google-modules/log-export/google//modules/bigquery"
-  version = "~> 5.2.0"
+  version = "~> 6.0.1"
 
   dataset_name             = "{{.logs_bigquery_dataset.dataset_id}}"
   project_id               = module.project.project_id
@@ -66,7 +66,7 @@ module "bigquery_destination" {
 
 module "storage_export" {
   source  = "terraform-google-modules/log-export/google"
-  version = "~> 5.2.0"
+  version = "~> 6.0.1"
 
   log_sink_name          = "{{get .logs_storage_bucket "sink_name" "storage-audit-logs-sink"}}"
   destination_uri        = "${module.storage_destination.destination_uri}"
@@ -82,7 +82,7 @@ module "storage_export" {
 // and set the actual expiry to be greater than this amount (7 years).
 module "storage_destination" {
   source  = "terraform-google-modules/log-export/google//modules/storage"
-  version = "~> 5.2.0"
+  version = "~> 6.0.1"
 
   storage_bucket_name      = "{{.logs_storage_bucket.name}}"
   project_id               = module.project.project_id


### PR DESCRIPTION
It fixes a deprecated syntax which is now an error in Terraform 1.0.

https://github.com/terraform-google-modules/terraform-google-log-export/releases/tag/v6.0.1