### PR TITLE
chore: Remove private catalog testing TODO

### DIFF
--- a/examples/tfengine/generated/devops/devops/variables.tf
+++ b/examples/tfengine/generated/devops/devops/variables.tf
@@ -33,8 +33,6 @@ variable "parent_id" {
   }
 }
 
-# TODO(ernestognw): Test with private catalog and validate it 
-# accepts nested data structures
 variable "project" {
   type = object({
     apis = list(string)

--- a/examples/tfengine/generated/folder_foundation/devops/variables.tf
+++ b/examples/tfengine/generated/folder_foundation/devops/variables.tf
@@ -33,8 +33,6 @@ variable "parent_id" {
   }
 }
 
-# TODO(ernestognw): Test with private catalog and validate it 
-# accepts nested data structures
 variable "project" {
   type = object({
     apis = list(string)

--- a/examples/tfengine/generated/multi_envs/devops/variables.tf
+++ b/examples/tfengine/generated/multi_envs/devops/variables.tf
@@ -36,8 +36,6 @@ variable "parent_id" {
   }
 }
 
-# TODO(ernestognw): Test with private catalog and validate it 
-# accepts nested data structures
 variable "project" {
   type = object({
     apis = list(string)

--- a/examples/tfengine/generated/org_foundation/devops/variables.tf
+++ b/examples/tfengine/generated/org_foundation/devops/variables.tf
@@ -33,8 +33,6 @@ variable "parent_id" {
   }
 }
 
-# TODO(ernestognw): Test with private catalog and validate it 
-# accepts nested data structures
 variable "project" {
   type = object({
     apis = list(string)

--- a/examples/tfengine/generated/team/devops/variables.tf
+++ b/examples/tfengine/generated/team/devops/variables.tf
@@ -33,8 +33,6 @@ variable "parent_id" {
   }
 }
 
-# TODO(ernestognw): Test with private catalog and validate it 
-# accepts nested data structures
 variable "project" {
   type = object({
     apis = list(string)

--- a/templates/tfengine/components/devops/variables.tf
+++ b/templates/tfengine/components/devops/variables.tf
@@ -49,8 +49,6 @@ variable "parent_id" {
   }
 }
 
-# TODO(ernestognw): Test with private catalog and validate it 
-# accepts nested data structures
 variable "project" {
   type = object({
     apis = list(string)


### PR DESCRIPTION
## Changes
- Remove TODO for testing agains private catalog

Notes: this is how private catalog handles complex data structures
![Screenshot 2021-07-08 11 57 44 AM](https://user-images.githubusercontent.com/33379285/124962027-c1631b00-dfe3-11eb-91bf-811e0f3805b5.png)
