### PR TITLE
Revert "Change Renovate config to only update modules."

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,6 @@
   "packageRules": [
     {
       "managers": ["regex", "terraform"],
-      "matchDepTypes": ["module"],
       "groupName": "terraform",
       "schedule": ["every 3 months on the first day of the month"]
     }


### PR DESCRIPTION
Reverts GoogleCloudPlatform/healthcare-data-protection-suite#925

The change starts breaking the pre-set schedule and the renovate PR no longer groups modules together.