### PR TITLE
Remove project recipe reference in audit recipe

### DIFF
--- a/docs/tfengine/schemas/audit.md
+++ b/docs/tfengine/schemas/audit.md
@@ -9,6 +9,7 @@
 | additional_filters | Additional filters for log collection and export. List entries will be        concatenated by "OR" operator. Refer to        <https://cloud.google.com/logging/docs/view/query-library> for query syntax.        Need to escape \ and " to preserve them in the final filter strings.        See example usages under "examples/tfengine/".        Logs with filter `"logName:\"logs/cloudaudit.googleapis.com\""` is always enabled. | array(string) | false | [] | - |
 | auditors_group | This group will be granted viewer access to the audit log dataset and        bucket as well as security reviewer permission on the root resource        specified. | string | true | - | - |
 | bigquery_location | Location of logs bigquery dataset. | string | false | - | - |
+| billing_account | ID of billing account to attach to this project. | string | false | - | - |
 | logs_bigquery_dataset | Bigquery Dataset to host audit logs for 1 year. Useful for querying recent activity. | object | true | - | - |
 | logs_bigquery_dataset.dataset_id | ID of Bigquery Dataset. | string | true | - | - |
 | logs_bigquery_dataset.sink_name | Name of the logs sink. | string | false | bigquery-audit-logs-sink | - |

--- a/docs/tfengine/schemas/audit.md
+++ b/docs/tfengine/schemas/audit.md
@@ -18,6 +18,6 @@
 | logs_storage_bucket.sink_name | Name of the logs sink. | string | false | storage-audit-logs-sink | - |
 | parent_id | ID of the parent GCP resource to apply the configuration. | string | false | - | ^[0-9]{8,25}$ |
 | parent_type | Type of parent GCP resource to apply the policy.        Must be one of 'organization' or 'folder'." | string | false | - | ^organization\|folder$ |
-| project | Config of project to host auditing resources | object | false | - | - |
-| project.project_id | ID of project. | string | false | - | ^[a-z][a-z0-9\-]{4,28}[a-z0-9]$ |
+| project | Config of project to host auditing resources | object | true | - | - |
+| project.project_id | ID of project. | string | true | - | ^[a-z][a-z0-9\-]{4,28}[a-z0-9]$ |
 | storage_location | Location of logs storage bucket. | string | false | - | - |

--- a/examples/tfengine/generated/folder_foundation/audit/main.tf
+++ b/examples/tfengine/generated/folder_foundation/audit/main.tf
@@ -32,10 +32,10 @@ module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 11.1.0"
 
-  name            = "example-audit"
-  org_id          = ""
-  folder_id       = "12345678"
-  billing_account = "000-000-000"
+  name            = var.project.project_id
+  org_id          = var.parent_type == "organization" ? var.parent_id : ""
+  folder_id       = var.parent_type == "folder" ? var.parent_id : ""
+  billing_account = var.billing_account
   lien            = true
   # Create and keep default service accounts when certain APIs are enabled.
   default_service_account = "keep"
@@ -50,6 +50,7 @@ module "project" {
     "logging.googleapis.com",
   ]
 }
+
 # Organization IAM Audit log configs to enable collection of all possible audit logs.
 resource "google_organization_iam_audit_config" "config" {
   count = var.parent_type == "organization" ? 1 : 0

--- a/examples/tfengine/generated/folder_foundation/audit/terraform.tfvars
+++ b/examples/tfengine/generated/folder_foundation/audit/terraform.tfvars
@@ -19,6 +19,10 @@ additional_filters = [
   "logName:\"logs/forseti\"",
   "logName:\"logs/application\"",
 ]
+billing_account = "000-000-000"
+project = {
+  project_id = "example-audit"
+}
 bigquery_location = "us-east1"
 logs_bigquery_dataset = {
   dataset_id = "1yr_folder_audit_logs"

--- a/examples/tfengine/generated/folder_foundation/audit/variables.tf
+++ b/examples/tfengine/generated/folder_foundation/audit/variables.tf
@@ -39,6 +39,28 @@ variable "bigquery_location" {
   description = "Location of logs bigquery dataset."
 }
 
+variable "billing_account" {
+  type        = string
+  description = "ID of billing account to attach to this project."
+}
+
+variable "project" {
+  type = object({
+    project_id = string
+  })
+  description = <<EOF
+    Config of project to host auditing resources
+
+    Fields:
+
+    * project_id = ID of project.
+  EOF
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project.project_id))
+    error_message = "Invalid project.project_id. Should be a string of 6 to 30 letters, digits, or hyphens. It must start with a letter, and cannot have a trailing hyphen. See https://cloud.google.com/resource-manager/docs/creating-managing-projects."
+  }
+}
+
 variable "logs_bigquery_dataset" {
   type = object({
     dataset_id = string

--- a/examples/tfengine/generated/multi_envs/audit/main.tf
+++ b/examples/tfengine/generated/multi_envs/audit/main.tf
@@ -32,10 +32,10 @@ module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 11.1.0"
 
-  name            = "example-audit"
-  org_id          = ""
-  folder_id       = "12345678"
-  billing_account = "000-000-000"
+  name            = var.project.project_id
+  org_id          = var.parent_type == "organization" ? var.parent_id : ""
+  folder_id       = var.parent_type == "folder" ? var.parent_id : ""
+  billing_account = var.billing_account
   lien            = true
   # Create and keep default service accounts when certain APIs are enabled.
   default_service_account = "keep"
@@ -50,6 +50,7 @@ module "project" {
     "logging.googleapis.com",
   ]
 }
+
 # Organization IAM Audit log configs to enable collection of all possible audit logs.
 resource "google_organization_iam_audit_config" "config" {
   count = var.parent_type == "organization" ? 1 : 0

--- a/examples/tfengine/generated/multi_envs/audit/terraform.tfvars
+++ b/examples/tfengine/generated/multi_envs/audit/terraform.tfvars
@@ -19,6 +19,10 @@ additional_filters = [
   "logName:\"logs/forseti\"",
   "logName:\"logs/application\"",
 ]
+billing_account = "000-000-000"
+project = {
+  project_id = "example-audit"
+}
 bigquery_location = "us-east1"
 logs_bigquery_dataset = {
   dataset_id = "1yr_folder_audit_logs"

--- a/examples/tfengine/generated/multi_envs/audit/variables.tf
+++ b/examples/tfengine/generated/multi_envs/audit/variables.tf
@@ -39,6 +39,28 @@ variable "bigquery_location" {
   description = "Location of logs bigquery dataset."
 }
 
+variable "billing_account" {
+  type        = string
+  description = "ID of billing account to attach to this project."
+}
+
+variable "project" {
+  type = object({
+    project_id = string
+  })
+  description = <<EOF
+    Config of project to host auditing resources
+
+    Fields:
+
+    * project_id = ID of project.
+  EOF
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project.project_id))
+    error_message = "Invalid project.project_id. Should be a string of 6 to 30 letters, digits, or hyphens. It must start with a letter, and cannot have a trailing hyphen. See https://cloud.google.com/resource-manager/docs/creating-managing-projects."
+  }
+}
+
 variable "logs_bigquery_dataset" {
   type = object({
     dataset_id = string

--- a/examples/tfengine/generated/org_foundation/audit/main.tf
+++ b/examples/tfengine/generated/org_foundation/audit/main.tf
@@ -32,9 +32,10 @@ module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 11.1.0"
 
-  name            = "example-audit"
-  org_id          = "12345678"
-  billing_account = "000-000-000"
+  name            = var.project.project_id
+  org_id          = var.parent_type == "organization" ? var.parent_id : ""
+  folder_id       = var.parent_type == "folder" ? var.parent_id : ""
+  billing_account = var.billing_account
   lien            = true
   # Create and keep default service accounts when certain APIs are enabled.
   default_service_account = "keep"
@@ -49,6 +50,7 @@ module "project" {
     "logging.googleapis.com",
   ]
 }
+
 # Organization IAM Audit log configs to enable collection of all possible audit logs.
 resource "google_organization_iam_audit_config" "config" {
   count = var.parent_type == "organization" ? 1 : 0

--- a/examples/tfengine/generated/org_foundation/audit/terraform.tfvars
+++ b/examples/tfengine/generated/org_foundation/audit/terraform.tfvars
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-parent_id         = "12345678"
-parent_type       = "organization"
-auditors_group    = "example-auditors@example.com"
+parent_id       = "12345678"
+parent_type     = "organization"
+auditors_group  = "example-auditors@example.com"
+billing_account = "000-000-000"
+project = {
+  project_id = "example-audit"
+}
 bigquery_location = "us-east1"
 logs_bigquery_dataset = {
   dataset_id = "1yr_org_audit_logs"

--- a/examples/tfengine/generated/org_foundation/audit/variables.tf
+++ b/examples/tfengine/generated/org_foundation/audit/variables.tf
@@ -39,6 +39,28 @@ variable "bigquery_location" {
   description = "Location of logs bigquery dataset."
 }
 
+variable "billing_account" {
+  type        = string
+  description = "ID of billing account to attach to this project."
+}
+
+variable "project" {
+  type = object({
+    project_id = string
+  })
+  description = <<EOF
+    Config of project to host auditing resources
+
+    Fields:
+
+    * project_id = ID of project.
+  EOF
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project.project_id))
+    error_message = "Invalid project.project_id. Should be a string of 6 to 30 letters, digits, or hyphens. It must start with a letter, and cannot have a trailing hyphen. See https://cloud.google.com/resource-manager/docs/creating-managing-projects."
+  }
+}
+
 variable "logs_bigquery_dataset" {
   type = object({
     dataset_id = string

--- a/templates/tfengine/components/audit/terraform.tfvars
+++ b/templates/tfengine/components/audit/terraform.tfvars
@@ -15,6 +15,10 @@ parent_id = "{{.parent_id}}"
 parent_type = "{{.parent_type}}"
 auditors_group = "{{.auditors_group}}"
 {{hclField . "additional_filters" -}}
+billing_account = "{{.billing_account}}"
+project = {
+  project_id = "{{.project.project_id}}"
+}
 bigquery_location ="{{.bigquery_location}}"
 logs_bigquery_dataset = {
   dataset_id = "{{.logs_bigquery_dataset.dataset_id}}"

--- a/templates/tfengine/components/audit/variables.tf
+++ b/templates/tfengine/components/audit/variables.tf
@@ -14,6 +14,7 @@ limitations under the License. */ -}}
 {{$props := .__schema__.properties -}}
 {{$logsBigQueryProps := $props.logs_bigquery_dataset.properties -}}
 {{$logsStorageProps := $props.logs_storage_bucket.properties -}}
+{{$projectProps := $props.project.properties -}}
 variable "additional_filters" {
   type = list(string)
   description = {{schemaDescription $props.additional_filters.description}}
@@ -28,6 +29,28 @@ variable "auditors_group" {
 variable "bigquery_location" {
   type = string
   description = {{schemaDescription $props.bigquery_location.description}}
+}
+
+variable "billing_account" {
+  type        = string
+  description = {{schemaDescription $props.billing_account.description}}
+}
+
+variable "project" {
+  type = object({
+    project_id = string
+  })
+  description = <<EOF
+    {{$props.project.description}}
+
+    Fields:
+
+    * project_id = {{$projectProps.project_id.description}}
+  EOF
+  validation {
+    condition     = can(regex("{{replace $projectProps.project_id.pattern "\\" ""}}", var.project.project_id))
+    error_message = "Invalid project.project_id. Should be a string of 6 to 30 letters, digits, or hyphens. It must start with a letter, and cannot have a trailing hyphen. See https://cloud.google.com/resource-manager/docs/creating-managing-projects."
+  }
 }
 
 variable "logs_bigquery_dataset" {

--- a/templates/tfengine/recipes/audit.hcl
+++ b/templates/tfengine/recipes/audit.hcl
@@ -36,6 +36,10 @@ schema = {
       type        = "string"
       pattern     = "^[0-9]{8,25}$"
     }
+    billing_account = {
+      description = "ID of billing account to attach to this project."
+      type        = "string"
+    }
     project = {
       description          = "Config of project to host auditing resources"
       type                 = "object"
@@ -124,17 +128,8 @@ schema = {
   }
 }
 
-template "project" {
-  recipe_path = "./project.hcl"
-  data = {
-    project = {
-      project_id = {{hcl .project.project_id}}
-      apis = [
-        "bigquery.googleapis.com",
-        "logging.googleapis.com",
-      ]
-    }
-  }
+template "deployment" {
+  recipe_path = "./deployment.hcl"
 }
 
 template "audit" {

--- a/templates/tfengine/recipes/audit.hcl
+++ b/templates/tfengine/recipes/audit.hcl
@@ -18,7 +18,8 @@ schema = {
   required = [
     "auditors_group",
     "logs_bigquery_dataset",
-    "logs_storage_bucket"
+    "logs_storage_bucket",
+    "project"
   ]
   properties = {
     parent_type = {
@@ -44,6 +45,9 @@ schema = {
       description          = "Config of project to host auditing resources"
       type                 = "object"
       additionalProperties = false
+      required = [
+        "project_id"
+      ]
       properties = {
         project_id = {
           description = "ID of project."


### PR DESCRIPTION
## Description

Removed the reference that `audit` recipe is doing to the `project` recipe. This will avoid future duplication of variables at `variables.tf` and `terraform.tfvars`