### PR TITLE
Use GA provider for cloud build triggers.

### DIFF
--- a/examples/tfengine/generated/devops/cicd/triggers.tf
+++ b/examples/tfengine/generated/devops/cicd/triggers.tf
@@ -15,7 +15,6 @@
 # ================== Triggers for "prod" environment ==================
 
 resource "google_cloudbuild_trigger" "validate_prod" {
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-validate-prod"
   description = "Terraform validate job triggered on push event."
@@ -45,7 +44,6 @@ resource "google_cloudbuild_trigger" "validate_prod" {
 }
 
 resource "google_cloudbuild_trigger" "plan_prod" {
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-plan-prod"
   description = "Terraform plan job triggered on push event."
@@ -78,7 +76,6 @@ resource "google_cloudbuild_trigger" "plan_prod" {
 resource "google_cloudbuild_trigger" "plan_scheduled_prod" {
   # Always disabled on push to branch.
   disabled    = true
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-plan-scheduled-prod"
   description = "Terraform plan job triggered on schedule."
@@ -131,7 +128,6 @@ resource "google_cloud_scheduler_job" "plan_scheduler_prod" {
 
 resource "google_cloudbuild_trigger" "apply_prod" {
   disabled    = true
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-apply-prod"
   description = "Terraform apply job triggered on push event and/or schedule."

--- a/examples/tfengine/generated/folder_foundation/cicd/triggers.tf
+++ b/examples/tfengine/generated/folder_foundation/cicd/triggers.tf
@@ -15,7 +15,6 @@
 # ================== Triggers for "prod" environment ==================
 
 resource "google_cloudbuild_trigger" "validate_prod" {
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-validate-prod"
   description = "Terraform validate job triggered on push event."
@@ -45,7 +44,6 @@ resource "google_cloudbuild_trigger" "validate_prod" {
 }
 
 resource "google_cloudbuild_trigger" "plan_prod" {
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-plan-prod"
   description = "Terraform plan job triggered on push event."
@@ -78,7 +76,6 @@ resource "google_cloudbuild_trigger" "plan_prod" {
 resource "google_cloudbuild_trigger" "plan_scheduled_prod" {
   # Always disabled on push to branch.
   disabled    = true
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-plan-scheduled-prod"
   description = "Terraform plan job triggered on schedule."
@@ -131,7 +128,6 @@ resource "google_cloud_scheduler_job" "plan_scheduler_prod" {
 
 resource "google_cloudbuild_trigger" "apply_prod" {
   disabled    = true
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-apply-prod"
   description = "Terraform apply job triggered on push event and/or schedule."

--- a/examples/tfengine/generated/multi_envs/cicd/triggers.tf
+++ b/examples/tfengine/generated/multi_envs/cicd/triggers.tf
@@ -15,7 +15,6 @@
 # ================== Triggers for "shared" environment ==================
 
 resource "google_cloudbuild_trigger" "validate_shared" {
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-validate-shared"
   description = "Terraform validate job triggered on push event."
@@ -43,7 +42,6 @@ resource "google_cloudbuild_trigger" "validate_shared" {
 }
 
 resource "google_cloudbuild_trigger" "plan_shared" {
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-plan-shared"
   description = "Terraform plan job triggered on push event."
@@ -72,7 +70,6 @@ resource "google_cloudbuild_trigger" "plan_shared" {
 
 resource "google_cloudbuild_trigger" "apply_shared" {
   disabled    = true
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-apply-shared"
   description = "Terraform apply job triggered on push event and/or schedule."
@@ -102,7 +99,6 @@ resource "google_cloudbuild_trigger" "apply_shared" {
 # ================== Triggers for "dev" environment ==================
 
 resource "google_cloudbuild_trigger" "validate_dev" {
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-validate-dev"
   description = "Terraform validate job triggered on push event."
@@ -130,7 +126,6 @@ resource "google_cloudbuild_trigger" "validate_dev" {
 }
 
 resource "google_cloudbuild_trigger" "apply_dev" {
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-apply-dev"
   description = "Terraform apply job triggered on push event and/or schedule."
@@ -160,7 +155,6 @@ resource "google_cloudbuild_trigger" "apply_dev" {
 # ================== Triggers for "prod" environment ==================
 
 resource "google_cloudbuild_trigger" "validate_prod" {
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-validate-prod"
   description = "Terraform validate job triggered on push event."
@@ -188,7 +182,6 @@ resource "google_cloudbuild_trigger" "validate_prod" {
 }
 
 resource "google_cloudbuild_trigger" "plan_prod" {
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-plan-prod"
   description = "Terraform plan job triggered on push event."
@@ -217,7 +210,6 @@ resource "google_cloudbuild_trigger" "plan_prod" {
 
 resource "google_cloudbuild_trigger" "apply_prod" {
   disabled    = true
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-apply-prod"
   description = "Terraform apply job triggered on push event and/or schedule."

--- a/examples/tfengine/generated/org_foundation/cicd/triggers.tf
+++ b/examples/tfengine/generated/org_foundation/cicd/triggers.tf
@@ -15,7 +15,6 @@
 # ================== Triggers for "prod" environment ==================
 
 resource "google_cloudbuild_trigger" "validate_prod" {
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-validate-prod"
   description = "Terraform validate job triggered on push event."
@@ -45,7 +44,6 @@ resource "google_cloudbuild_trigger" "validate_prod" {
 }
 
 resource "google_cloudbuild_trigger" "plan_prod" {
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-plan-prod"
   description = "Terraform plan job triggered on push event."
@@ -76,7 +74,6 @@ resource "google_cloudbuild_trigger" "plan_prod" {
 
 resource "google_cloudbuild_trigger" "apply_prod" {
   disabled    = true
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-apply-prod"
   description = "Terraform apply job triggered on push event and/or schedule."

--- a/examples/tfengine/generated/team/cicd/triggers.tf
+++ b/examples/tfengine/generated/team/cicd/triggers.tf
@@ -15,7 +15,6 @@
 # ================== Triggers for "prod" environment ==================
 
 resource "google_cloudbuild_trigger" "validate_prod" {
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-validate-prod"
   description = "Terraform validate job triggered on push event."
@@ -45,7 +44,6 @@ resource "google_cloudbuild_trigger" "validate_prod" {
 }
 
 resource "google_cloudbuild_trigger" "plan_prod" {
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-plan-prod"
   description = "Terraform plan job triggered on push event."
@@ -76,7 +74,6 @@ resource "google_cloudbuild_trigger" "plan_prod" {
 
 resource "google_cloudbuild_trigger" "apply_prod" {
   disabled    = true
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-apply-prod"
   description = "Terraform apply job triggered on push event and/or schedule."

--- a/templates/tfengine/components/cicd/triggers.tf
+++ b/templates/tfengine/components/cicd/triggers.tf
@@ -36,7 +36,6 @@ resource "google_cloudbuild_trigger" "validate_{{.name}}" {
   {{- if not (get .triggers.validate "run_on_push" true)}}
   disabled    = true
   {{- end}}
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-validate-{{.name}}"
   description = "Terraform validate job triggered on push event."
@@ -81,7 +80,6 @@ resource "google_cloudbuild_trigger" "validate_{{.name}}" {
 resource "google_cloudbuild_trigger" "validate_scheduled_{{.name}}" {
   # Always disabled on push to branch.
   disabled    = true
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-validate-scheduled-{{.name}}"
   description = "Terraform validate job triggered on schedule."
@@ -150,7 +148,6 @@ resource "google_cloudbuild_trigger" "plan_{{.name}}" {
   {{- if not (get .triggers.plan "run_on_push" true)}}
   disabled    = true
   {{- end}}
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-plan-{{.name}}"
   description = "Terraform plan job triggered on push event."
@@ -195,7 +192,6 @@ resource "google_cloudbuild_trigger" "plan_{{.name}}" {
 resource "google_cloudbuild_trigger" "plan_scheduled_{{.name}}" {
   # Always disabled on push to branch.
   disabled    = true
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-plan-scheduled-{{.name}}"
   description = "Terraform plan job triggered on schedule."
@@ -264,7 +260,6 @@ resource "google_cloudbuild_trigger" "apply_{{.name}}" {
   {{- if not (get .triggers.apply "run_on_push" true)}}
   disabled    = true
   {{- end}}
-  provider    = google-beta
   project     = var.project_id
   name        = "tf-apply-{{.name}}"
   description = "Terraform apply job triggered on push event and/or schedule."


### PR DESCRIPTION
Cloud Build Trigger API is in GA:
https://cloud.google.com/build/docs/api/reference/rest/v1/projects.triggers/create?hl=en_US
(note the v1 label).

Fixes #998