### PR TITLE
Add passthrough to the project recipe

### DIFF
--- a/internal/tfengine/tfengine.go
+++ b/internal/tfengine/tfengine.go
@@ -182,11 +182,9 @@ func dumpTemplate(conf *Config, pwd, cacheDir, outputPath string, ti *templateIn
 	// Pass through specified keys that should be validated against the
 	// schema.
 	for _, k := range ti.Passthrough {
-		v, ok := conf.Data[k]
-		if !ok {
-			return fmt.Errorf("did not find key %q to pass through to child template", k)
+		if v, ok := conf.Data[k]; ok {
+			ti.Data[k] = v
 		}
-		ti.Data[k] = v
 	}
 
 	switch {

--- a/internal/tfengine/tfengine.go
+++ b/internal/tfengine/tfengine.go
@@ -179,8 +179,9 @@ func dumpTemplate(conf *Config, pwd, cacheDir, outputPath string, ti *templateIn
 		return err
 	}
 
-	// Pass through specified keys that should be validated against the
-	// schema.
+	// Pass through keys that should be validated against the schema.
+	// Don't do error checking if keys are missing, instead let schemas
+	// in the child templates do the validation.
 	for _, k := range ti.Passthrough {
 		if v, ok := conf.Data[k]; ok {
 			ti.Data[k] = v

--- a/templates/tfengine/recipes/project.hcl
+++ b/templates/tfengine/recipes/project.hcl
@@ -155,6 +155,11 @@ schema = {
 
 template "deployment" {
   recipe_path = "./deployment.hcl"
+  passthrough = [
+    "state_bucket",
+    "state_path_prefix",
+    "terraform_addons",
+  ]
 }
 
 template "project" {


### PR DESCRIPTION
Also removed the error checking, it doesn't work here because one of the fields is optional and isn't always provided. It might be simpler this way and to just let the schema in the child recipe set certain fields as required or not.

Fixes https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite/issues/951