### PR TITLE
Add more logging to the deletion check

### DIFF
--- a/examples/tfengine/generated/devops/cicd/configs/tf-deletion-check.sh
+++ b/examples/tfengine/generated/devops/cicd/configs/tf-deletion-check.sh
@@ -49,6 +49,9 @@ for planfile in $(find "$(pwd)" -name 'plan.tfplan'); do
   plandir="$(dirname ${planfile})"
   pushd "${plandir}" &>/dev/null
 
+  # Echo the planfile to help with debugging.
+  terraform show -json "$(basename ${planfile}"
+
   delchanges="$(terraform show -json $(basename ${planfile}) | jq -rM '.resource_changes[]? | select(.change.actions | index("delete")) | .address')"
 
   # Filter through the allowlist, if configured.

--- a/examples/tfengine/generated/folder_foundation/cicd/configs/tf-deletion-check.sh
+++ b/examples/tfengine/generated/folder_foundation/cicd/configs/tf-deletion-check.sh
@@ -49,6 +49,9 @@ for planfile in $(find "$(pwd)" -name 'plan.tfplan'); do
   plandir="$(dirname ${planfile})"
   pushd "${plandir}" &>/dev/null
 
+  # Echo the planfile to help with debugging.
+  terraform show -json "$(basename ${planfile}"
+
   delchanges="$(terraform show -json $(basename ${planfile}) | jq -rM '.resource_changes[]? | select(.change.actions | index("delete")) | .address')"
 
   # Filter through the allowlist, if configured.

--- a/examples/tfengine/generated/multi_envs/cicd/configs/tf-deletion-check.sh
+++ b/examples/tfengine/generated/multi_envs/cicd/configs/tf-deletion-check.sh
@@ -49,6 +49,9 @@ for planfile in $(find "$(pwd)" -name 'plan.tfplan'); do
   plandir="$(dirname ${planfile})"
   pushd "${plandir}" &>/dev/null
 
+  # Echo the planfile to help with debugging.
+  terraform show -json "$(basename ${planfile}"
+
   delchanges="$(terraform show -json $(basename ${planfile}) | jq -rM '.resource_changes[]? | select(.change.actions | index("delete")) | .address')"
 
   # Filter through the allowlist, if configured.

--- a/examples/tfengine/generated/org_foundation/cicd/configs/tf-deletion-check.sh
+++ b/examples/tfengine/generated/org_foundation/cicd/configs/tf-deletion-check.sh
@@ -49,6 +49,9 @@ for planfile in $(find "$(pwd)" -name 'plan.tfplan'); do
   plandir="$(dirname ${planfile})"
   pushd "${plandir}" &>/dev/null
 
+  # Echo the planfile to help with debugging.
+  terraform show -json "$(basename ${planfile}"
+
   delchanges="$(terraform show -json $(basename ${planfile}) | jq -rM '.resource_changes[]? | select(.change.actions | index("delete")) | .address')"
 
   # Filter through the allowlist, if configured.

--- a/examples/tfengine/generated/team/cicd/configs/tf-deletion-check.sh
+++ b/examples/tfengine/generated/team/cicd/configs/tf-deletion-check.sh
@@ -49,6 +49,9 @@ for planfile in $(find "$(pwd)" -name 'plan.tfplan'); do
   plandir="$(dirname ${planfile})"
   pushd "${plandir}" &>/dev/null
 
+  # Echo the planfile to help with debugging.
+  terraform show -json "$(basename ${planfile}"
+
   delchanges="$(terraform show -json $(basename ${planfile}) | jq -rM '.resource_changes[]? | select(.change.actions | index("delete")) | .address')"
 
   # Filter through the allowlist, if configured.

--- a/templates/tfengine/components/cicd/configs/tf-deletion-check.sh
+++ b/templates/tfengine/components/cicd/configs/tf-deletion-check.sh
@@ -49,6 +49,9 @@ for planfile in $(find "$(pwd)" -name 'plan.tfplan'); do
   plandir="$(dirname ${planfile})"
   pushd "${plandir}" &>/dev/null
 
+  # Echo the planfile to help with debugging.
+  terraform show -json "$(basename ${planfile}"
+
   delchanges="$(terraform show -json $(basename ${planfile}) | jq -rM '.resource_changes[]? | select(.change.actions | index("delete")) | .address')"
 
   # Filter through the allowlist, if configured.


### PR DESCRIPTION
Sometimes this check fails with "parse error: Invalid numeric literal at line 1, column 2". This looks like it's coming from jq failing to parse the output of terraform show, so log that output separately for debugging.