### PR TITLE
Add simple commit log to the binaries release

### DIFF
--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -48,9 +48,13 @@ jobs:
       run: |
         set -x
 
-        # Install the latest version of hub
+        # Install the latest version of hub.
         ./build/install-hub.sh
 
-        # Create the release with all binaries
+        # Get a commit log since the previous tag.
+        previous_tag="$(git tag | grep -v '{{ github.ref }}' | grep '^v.*' | sort -Vr | head -1)"
+        changes="Changes:\n$(git log --pretty='format:* %s (by %an) on %cD' ${previous_tag}..HEAD)"
+
+        # Create the release with all binaries.
         version="$(echo ${{ github.ref }} | sed -e 's|^refs/tags/||')"
-        bin/hub release create $(printf -- ' --attach=%s' ./*-amd64) -m "Binaries release version ${version}" "${version}"
+        bin/hub release create $(printf -- ' --attach=%s' ./*-amd64) -m "Binaries release version ${version}" -m "${changes}" "${version}"

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -52,8 +52,7 @@ jobs:
         ./build/install-hub.sh
 
         # Get a commit log since the previous tag.
-        previous_tag="$(git tag | grep -v '{{ github.ref }}' | grep '^v.*' | sort -Vr | head -1)"
-        changes="Changes:\n$(git log --pretty='format:* %s (by %an) on %cD' ${previous_tag}..HEAD -- internal/ cmd/ go.mod)"
+        changes="$(./build/changelog_binaries.sh)"
 
         # Create the release with all binaries.
         version="$(echo ${{ github.ref }} | sed -e 's|^refs/tags/||')"

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -53,7 +53,7 @@ jobs:
 
         # Get a commit log since the previous tag.
         previous_tag="$(git tag | grep -v '{{ github.ref }}' | grep '^v.*' | sort -Vr | head -1)"
-        changes="Changes:\n$(git log --pretty='format:* %s (by %an) on %cD' ${previous_tag}..HEAD)"
+        changes="Changes:\n$(git log --pretty='format:* %s (by %an) on %cD' ${previous_tag}..HEAD -- internal/ cmd/ go.mod)"
 
         # Create the release with all binaries.
         version="$(echo ${{ github.ref }} | sed -e 's|^refs/tags/||')"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -101,6 +101,10 @@ To trigger an automated release:
 1. Follow the workflow on the
    [Actions page](https://github.com/GoogleCloudPlatform/healthcare-data-protection-suite/actions).
 
+1. Binaries releases will also auto-generate a simple changelog from the commits made since the previous tag.
+   Look at the new release in GitHub and edit this changelog if required, as some PRs are not important
+   and including them in the notes adds clutter and can confuse users.
+
 ## Manual releases
 
 If automation is not available, releases can be made manually. Follow the steps above to create and push a tag,
@@ -120,6 +124,16 @@ then manually build and upload the release artifacts as described below.
 
 1. Create a release from the `${version}` tag and upload all the `tfengine_*`,
    `policygen_*` and `tfimport_*` binaries as assets.
+
+1. Generate a changelog:
+
+   ```bash
+   ./build/changelog_binaries.sh
+   ```
+
+1. Edit this changelog if required, as some PRs are not important and including them in the notes adds clutter and can confuse users.
+
+1. Add the changelog to the release description.
 
 ### Templates
 
@@ -157,7 +171,7 @@ Follow instructions to install it, then run one of the following commands:
 1. For binaries:
 
    ```bash
-   hub release create $(printf -- ' --attach=%s' ./*-amd64) -m "Binaries release version ${version}" "${version}"
+   hub release create $(printf -- ' --attach=%s' ./*-amd64) -m "Binaries release version ${version}" -m "$(./build/changelog_binaries.sh)" "${version}"
    ```
 
 1. For templates:

--- a/build/changelog_binaries.sh
+++ b/build/changelog_binaries.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generates a simple commit log for changes to the binaries between the last two tags.
+
+latest_tag="$(git tag | grep '^v.*' | sort -Vr | head -1)"
+previous_tag="$(git tag | grep '^v.*' | sort -Vr | head -2 | tail -1)"
+echo -e "Changes:\n$(git log --pretty='format:- %s (by %an) on %cs' ${previous_tag}..${latest_tag} -- internal/ cmd/ go.mod)"


### PR DESCRIPTION
Opening this PR for discussion/consideration. This is naive and simple, but is still useful as it shows exactly what went into each binaries release and saves having to run `git log` to confirm that a release contains a specific feature.